### PR TITLE
Enh/ginkgo build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,4 +33,8 @@ repos:
     - id: detect-secrets
       exclude: example.secrets
       files: ^(tests|examples)/.*\.py$
-
+  - repo: https://github.com/cheshirekow/cmake-format-precommit
+    rev: v0.6.10
+    hooks:
+      - id: cmake-format
+      - id: cmake-lint

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,50 +6,53 @@ enable_testing()
 # Find Python interpreter and library
 find_package(Python COMPONENTS Interpreter Development)
 
-# Find OpenMPI
-#find_package(MPI REQUIRED)
+# Find OpenMPI find_package(MPI REQUIRED)
 
 # Find pybind11
 find_package(pybind11 QUIET)
 
 # Fetch pybind11 if not found
 if(NOT pybind11_FOUND)
-    # If not found, fetch Pybind11
-    include(FetchContent)
-    FetchContent_Declare(
-        pybind11
-        GIT_REPOSITORY https://github.com/pybind/pybind11.git
-        GIT_TAG        v2.12.0 
-    )
-    FetchContent_MakeAvailable(pybind11)
+  # If not found, fetch Pybind11
+  include(FetchContent)
+  FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11.git
+    GIT_TAG v2.12.0)
+  FetchContent_MakeAvailable(pybind11)
 endif()
 
-# Find  Ginkgo
-#find_package(Ginkgo 1.7.0 QUIET)
+# Find  Ginkgo find_package(Ginkgo 1.7.0 QUIET)
 find_package(ginkgo QUIET)
 
 # Fetch Ginkgo if not found
 if(NOT ginkgo_FOUND)
-    # If not found, fetch Ginkgo
-    include(FetchContent)
-    FetchContent_Declare(
-        ginkgo
-        GIT_REPOSITORY https://github.com/ginkgo-project/ginkgo.git
-        GIT_TAG        v1.7.0  
-    )
-    FetchContent_MakeAvailable(ginkgo)
+  # If not found, fetch Ginkgo
+  include(FetchContent)
+  if(NOT DEFINED GINKGO_BUILD_TESTS)
+    set(GINKGO_BUILD_TESTS OFF)
+  endif()
+  if(NOT DEFINED GINKGO_BUILD_BENCHMARKS)
+    set(GINKGO_BUILD_BENCHMARKS OFF)
+  endif()
+  if(NOT DEFINED GINKGO_BUILD_EXAMPLES)
+    set(GINKGO_BUILD_EXAMPLES OFF)
+  endif()
+  FetchContent_Declare(
+    ginkgo
+    GIT_REPOSITORY https://github.com/ginkgo-project/ginkgo.git
+    GIT_TAG v1.7.0)
+  FetchContent_MakeAvailable(ginkgo)
 
 endif()
 
 pybind11_add_module(pyGinkgo ${PROJECT_SOURCE_DIR}/src/python.cpp)
 
-    target_include_directories(pyGinkgo PRIVATE ${Ginkgo_BINARY_DIR}/include)
-    target_link_libraries(pyGinkgo PRIVATE Ginkgo::ginkgo)
-    set_property(TARGET pyGinkgo PROPERTY CXX_STANDARD 14)
+target_include_directories(pyGinkgo PRIVATE ${Ginkgo_BINARY_DIR}/include)
+target_link_libraries(pyGinkgo PRIVATE Ginkgo::ginkgo)
+set_property(TARGET pyGinkgo PROPERTY CXX_STANDARD 14)
 
-#adding tests
+# adding tests
 add_test(NAME pyginkgo_import_test
-         COMMAND ${PYTHON_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_import.py)    
-         
-
-
+         COMMAND ${PYTHON_EXECUTABLE} -m pytest
+                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_import.py)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,38 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 22,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "develop",
+      "hidden": true
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja"
+    },
+    {
+      "name": "ninja-develop",
+      "inherits": [
+        "develop",
+        "ninja"
+      ],
+      "displayName": "Build pyGinkgo bindings",
+      "description": "Build pyGinkgo bindings",
+      "binaryDir": "${sourceDir}/build/Develop"
+    }
+
+  ],
+  "buildPresets": [
+    {
+      "name": "ninja-develop",
+      "displayName": "Build for CPUs only with unit tests enabled",
+      "configurePreset": "ninja-develop",
+      "configuration": "ninja-develop"
+    }
+   ]
+}


### PR DESCRIPTION
# Description
This PR speeds up the Ginkgo build by switching off non necessary components like ginkgo benchmarks, tests and examples.

# Additional changes:
- Adds a basic CMakePresets.json
- Adds cmake-format to pre-commit
- Formats CMakeLists.txt