### PR TITLE
Enforcing pre-commit checks via static checks

### DIFF
--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -5,6 +5,18 @@ on:
     pull_request:
       types: [opened, synchronize]
 jobs:
+  pre-commit-checks:
+    name: Pre-commit checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files
   typos-check:
     name: Spell check
     runs-on: ubuntu-latest
@@ -23,7 +35,7 @@ jobs:
           pip3 install reuse
       - name: Execute reuse linter
         run: |
-          reuse lint
+          reuse lint       
   changelog:
     name: Changelog check
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
Added a job to enforce pre-commit checks in [static_checks.yaml](https://github.com/Helmholtz-AI-Energy/pyGinkgo/blob/enh/linting/.github/workflows/static_checks.yaml)

Fixes #29 

## Type of change


- [ ] New feature (non-breaking change which adds functionality)


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

