### PR TITLE
Add clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,107 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories:
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        c++17
+TabWidth:        4
+UseTab:          Never
+...

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -11,6 +11,10 @@ Files: .gitignore
 Copyright: 2024 pyGinkgo authors
 License: Unlicense
 
+Files: .clang-format
+Copyright: 2024 pyGinkgo authors
+License: Unlicense
+
 Files: *.yaml
 Copyright: 2024 pyGinkgo authors
 License: Unlicense

--- a/src/array.cpp
+++ b/src/array.cpp
@@ -7,56 +7,59 @@
 
 namespace py = pybind11;
 
-void init_array(py::module_ &module) {
-  py::class_<gko::array<ValueType>>(module, "array", py::buffer_protocol())
-      .def(py::init<std::shared_ptr<const gko::Executor>, int>())
-      .def(py::init<std::shared_ptr<const gko::Executor>,
-                    gko::array<ValueType> &>())
-      .def(py::init(
-          [](std::shared_ptr<gko::Executor> exec,
-             py::array_t<double, py::array::c_style | py::array::forcecast> b) {
-            // for documentation of the second argument see
-            // see
-            // https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#arrays
-            /* Request a buffer descriptor from Python */
-            py::buffer_info info = b.request();
+void init_array(py::module_ &module)
+{
+    py::class_<gko::array<ValueType>>(module, "array", py::buffer_protocol())
+        .def(py::init<std::shared_ptr<const gko::Executor>, int>())
+        .def(py::init<std::shared_ptr<const gko::Executor>,
+                      gko::array<ValueType> &>())
+        .def(py::init(
+            [](std::shared_ptr<gko::Executor> exec,
+               py::array_t<double, py::array::c_style | py::array::forcecast>
+                   b) {
+                // for documentation of the second argument see
+                // see
+                // https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#arrays
+                /* Request a buffer descriptor from Python */
+                py::buffer_info info = b.request();
 
-            if (info.format != py::format_descriptor<ValueType>::format()) {
-              throw std::runtime_error("Incompatible dtype");
-            }
+                if (info.format != py::format_descriptor<ValueType>::format()) {
+                    throw std::runtime_error("Incompatible dtype");
+                }
 
-            auto ref = gko::ReferenceExecutor::create();
+                auto ref = gko::ReferenceExecutor::create();
 
-            if (info.ndim != 1) {
-              throw std::runtime_error("Only 1D arrays are supported");
-            }
+                if (info.ndim != 1) {
+                    throw std::runtime_error("Only 1D arrays are supported");
+                }
 
-            auto elems = info.shape[0];
+                auto elems = info.shape[0];
 
-            return gko::array<ValueType>(exec, (ValueType *)info.ptr,
-                                         (ValueType *)info.ptr + elems);
-          }))
-      .def_buffer([](gko::array<ValueType> &a) -> py::buffer_info {
-        return py::buffer_info(
-            a.get_data(),                               /* Pointer to buffer */
-            sizeof(ValueType),                          /* Size of one scalar */
-            py::format_descriptor<ValueType>::format(), /* Python struct-style
-                                                           format descriptor */
-            1,              /* Number of dimensions */
-            {a.get_size()}, /* Buffer dimensions */
-            {
-                sizeof(ValueType) /* Strides (in bytes) for each index */
-            });
-      })
-      .def("fill", &gko::array<ValueType>::fill,
-           "Fill the array with the given value.")
-      .def("get_size", &gko::array<ValueType>::get_num_elems)
-      .def("at", [](const gko::array<ValueType> &arr, int idx) {
-        return arr.get_const_data()[idx];
-      });
+                return gko::array<ValueType>(exec, (ValueType *)info.ptr,
+                                             (ValueType *)info.ptr + elems);
+            }))
+        .def_buffer([](gko::array<ValueType> &a) -> py::buffer_info {
+            return py::buffer_info(
+                a.get_data(),      /* Pointer to buffer */
+                sizeof(ValueType), /* Size of one scalar */
+                py::format_descriptor<
+                    ValueType>::format(), /* Python struct-style
+                                             format descriptor */
+                1,                        /* Number of dimensions */
+                {a.get_size()},           /* Buffer dimensions */
+                {
+                    sizeof(ValueType) /* Strides (in bytes) for each index */
+                });
+        })
+        .def("fill", &gko::array<ValueType>::fill,
+             "Fill the array with the given value.")
+        .def("get_size", &gko::array<ValueType>::get_num_elems)
+        .def("at", [](const gko::array<ValueType> &arr, int idx) {
+            return arr.get_const_data()[idx];
+        });
 
-  module.def(
-      "reduce_add",
-      pybind11::overload_cast<const gko::array<ValueType> &, const ValueType>(
-          &gko::reduce_add<ValueType>));
+    module.def(
+        "reduce_add",
+        pybind11::overload_cast<const gko::array<ValueType> &, const ValueType>(
+            &gko::reduce_add<ValueType>));
 }

--- a/src/dense.cpp
+++ b/src/dense.cpp
@@ -4,192 +4,195 @@
 
 #include "python.hpp"
 
-void init_dense(py::module_ &module_matrix) {
+void init_dense(py::module_ &module_matrix)
+{
+    module_matrix.def("read_dense", [](const std::string &fn,
+                                       std::shared_ptr<gko::Executor> exec) {
+        return gko::share(
+            gko::read<gko::matrix::Dense<ValueType>>(std::ifstream(fn), exec));
+    });
 
-  module_matrix.def("read_dense", [](const std::string &fn,
-                                     std::shared_ptr<gko::Executor> exec) {
-    return gko::share(
-        gko::read<gko::matrix::Dense<ValueType>>(std::ifstream(fn), exec));
-  });
-
-  /* function to create a dense matrix from py::buffer object
-   *
-   */
-  auto init_func = [](std::shared_ptr<gko::Executor> exec, py::buffer b) {
-    /* Request a buffer descriptor from Python */
-    py::buffer_info info = b.request();
-
-    if (info.format != py::format_descriptor<ValueType>::format())
-      throw std::runtime_error("Incompatible dtype");
-
-    /* create a view into numpy data */
-    auto elems =
-        (info.ndim == 1) ? info.shape[0] : info.shape[0] * info.shape[1];
-
-    auto view = gko::array<ValueType>::view(exec->get_master(), elems,
-                                            (ValueType *)info.ptr);
-
-    auto rows = info.shape[0];
-    auto cols = (info.ndim == 1) ? 1 : info.shape[1];
-
-    return gko::matrix::Dense<ValueType>::create(exec, gko::dim<2>{rows, cols},
-                                                 view, cols);
-  };
-
-  py::class_<gko::matrix::Dense<ValueType>,
-             std::shared_ptr<gko::matrix::Dense<ValueType>>, gko::LinOp>(
-      module_matrix, "dense", py::buffer_protocol())
-      .def(py::init([init_func](py::buffer b) {
-        auto ref = gko::ReferenceExecutor::create();
-        return init_func(ref, b);
-      }))
-      .def(py::init([init_func](std::shared_ptr<gko::Executor> exec,
-                                py::buffer b) { return init_func(exec, b); }))
-      .def(py::init([](std::shared_ptr<gko::Executor> exec) {
-        return gko::share(gko::matrix::Dense<ValueType>::create(exec));
-      }))
-      .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim) {
-        return gko::share(gko::matrix::Dense<ValueType>::create(
-            exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()}));
-      }))
-      .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,
-                       int stride) {
-        return gko::share(gko::matrix::Dense<ValueType>::create(
-            exec, gko::dim<2>{dim[0].cast<int>(), dim[1].cast<int>()}, stride));
-      }))
-      .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,
-                       py::buffer b, size_t stride) {
+    /* function to create a dense matrix from py::buffer object
+     *
+     */
+    auto init_func = [](std::shared_ptr<gko::Executor> exec, py::buffer b) {
+        /* Request a buffer descriptor from Python */
         py::buffer_info info = b.request();
-        if (info.format != py::format_descriptor<ValueType>::format())
-          throw std::runtime_error("Incompatible dtype");
 
-        auto ref = gko::ReferenceExecutor::create();
+        if (info.format != py::format_descriptor<ValueType>::format())
+            throw std::runtime_error("Incompatible dtype");
 
         /* create a view into numpy data */
         auto elems =
             (info.ndim == 1) ? info.shape[0] : info.shape[0] * info.shape[1];
 
-        auto view =
-            gko::array<ValueType>::view(ref, elems, (ValueType *)info.ptr);
+        auto view = gko::array<ValueType>::view(exec->get_master(), elems,
+                                                (ValueType *)info.ptr);
 
         auto rows = info.shape[0];
         auto cols = (info.ndim == 1) ? 1 : info.shape[1];
 
-        return gko::share(gko::matrix::Dense<ValueType>::create(
-            exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},
-            view, stride));
-      }))
-      .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,
-                       gko::array<ValueType> view, size_t stride) {
-        return gko::share(gko::matrix::Dense<ValueType>::create(
-            exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},
-            view, stride));
-      }))
-      .def("__repr__",
-           [](const gko::matrix::Dense<ValueType> &o) {
-             auto str = std::string("pygko.matrix.Dense object of size ");
-             auto elems = o.get_num_stored_elements();
-             str += std::to_string(elems);
-             if (o.get_executor() == o.get_executor()->get_master()) {
-               str += " on host";
-               if (elems < 10) {
-                 str += " [ ";
-                 for (int i = 0; i < elems; i++) {
-                   str += std::to_string(o.at(i));
-                   str += " ";
+        return gko::matrix::Dense<ValueType>::create(
+            exec, gko::dim<2>{rows, cols}, view, cols);
+    };
+
+    py::class_<gko::matrix::Dense<ValueType>,
+               std::shared_ptr<gko::matrix::Dense<ValueType>>, gko::LinOp>(
+        module_matrix, "dense", py::buffer_protocol())
+        .def(py::init([init_func](py::buffer b) {
+            auto ref = gko::ReferenceExecutor::create();
+            return init_func(ref, b);
+        }))
+        .def(py::init([init_func](std::shared_ptr<gko::Executor> exec,
+                                  py::buffer b) { return init_func(exec, b); }))
+        .def(py::init([](std::shared_ptr<gko::Executor> exec) {
+            return gko::share(gko::matrix::Dense<ValueType>::create(exec));
+        }))
+        .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim) {
+            return gko::share(gko::matrix::Dense<ValueType>::create(
+                exec,
+                gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()}));
+        }))
+        .def(py::init(
+            [](std::shared_ptr<gko::Executor> exec, py::tuple dim, int stride) {
+                return gko::share(gko::matrix::Dense<ValueType>::create(
+                    exec, gko::dim<2>{dim[0].cast<int>(), dim[1].cast<int>()},
+                    stride));
+            }))
+        .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,
+                         py::buffer b, size_t stride) {
+            py::buffer_info info = b.request();
+            if (info.format != py::format_descriptor<ValueType>::format())
+                throw std::runtime_error("Incompatible dtype");
+
+            auto ref = gko::ReferenceExecutor::create();
+
+            /* create a view into numpy data */
+            auto elems = (info.ndim == 1) ? info.shape[0]
+                                          : info.shape[0] * info.shape[1];
+
+            auto view =
+                gko::array<ValueType>::view(ref, elems, (ValueType *)info.ptr);
+
+            auto rows = info.shape[0];
+            auto cols = (info.ndim == 1) ? 1 : info.shape[1];
+
+            return gko::share(gko::matrix::Dense<ValueType>::create(
+                exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},
+                view, stride));
+        }))
+        .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,
+                         gko::array<ValueType> view, size_t stride) {
+            return gko::share(gko::matrix::Dense<ValueType>::create(
+                exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},
+                view, stride));
+        }))
+        .def("__repr__",
+             [](const gko::matrix::Dense<ValueType> &o) {
+                 auto str = std::string("pygko.matrix.Dense object of size ");
+                 auto elems = o.get_num_stored_elements();
+                 str += std::to_string(elems);
+                 if (o.get_executor() == o.get_executor()->get_master()) {
+                     str += " on host";
+                     if (elems < 10) {
+                         str += " [ ";
+                         for (int i = 0; i < elems; i++) {
+                             str += std::to_string(o.at(i));
+                             str += " ";
+                         }
+                     }
+                     str += " ] ";
                  }
-               }
-               str += " ] ";
-             }
-             return str;
-           })
-      .def("copy_to_host",
-           [](gko::matrix::Dense<ValueType> &m) {
-             auto host_exec = m.get_executor()->get_master();
-             std::cout << __FILE__ << "Warning creating a copy of dense\n";
-             if (m.get_executor() != host_exec) {
-               auto host_dense =
-                   gko::share(gko::matrix::Dense<ValueType>::create(host_exec));
-               host_dense->operator=(m);
-               return host_dense;
-             } else {
-               return std::make_shared<gko::matrix::Dense<ValueType>>(m);
-             }
-           })
-      .def_buffer([](gko::matrix::Dense<ValueType> &m) -> py::buffer_info {
-        // buffer info needs data on host, thus if data is on device it
-        // should be copied to host first
-        size_t rows = m.get_num_stored_elements() / m.get_stride();
-        size_t cols = m.get_stride();
-        size_t dim = (m.get_stride() == 1) ? 1 : 2;
+                 return str;
+             })
+        .def("copy_to_host",
+             [](gko::matrix::Dense<ValueType> &m) {
+                 auto host_exec = m.get_executor()->get_master();
+                 std::cout << __FILE__ << "Warning creating a copy of dense\n";
+                 if (m.get_executor() != host_exec) {
+                     auto host_dense = gko::share(
+                         gko::matrix::Dense<ValueType>::create(host_exec));
+                     host_dense->operator=(m);
+                     return host_dense;
+                 } else {
+                     return std::make_shared<gko::matrix::Dense<ValueType>>(m);
+                 }
+             })
+        .def_buffer([](gko::matrix::Dense<ValueType> &m) -> py::buffer_info {
+            // buffer info needs data on host, thus if data is on device it
+            // should be copied to host first
+            size_t rows = m.get_num_stored_elements() / m.get_stride();
+            size_t cols = m.get_stride();
+            size_t dim = (m.get_stride() == 1) ? 1 : 2;
 
-        ValueType *buffer_ptr = nullptr;
-        if (m.get_executor() != m.get_executor()->get_master()) {
-          GKO_NOT_IMPLEMENTED;
-        }
-        buffer_ptr = m.get_values();
+            ValueType *buffer_ptr = nullptr;
+            if (m.get_executor() != m.get_executor()->get_master()) {
+                GKO_NOT_IMPLEMENTED;
+            }
+            buffer_ptr = m.get_values();
 
-        if (dim == 1) {
-          return py::buffer_info(
-              buffer_ptr,        /* Pointer to buffer */
-              sizeof(ValueType), /* Size of one scalar */
-              py::format_descriptor<ValueType>::format(), /* Python
-                                                          struct-style
-                                                          format
-                                                          descriptor */
-              dim,                /* Number of dimensions */
-              {rows},             /* Buffer dimensions */
-              {sizeof(ValueType)} /* Strides (in bytes) for each index */
-          );
-        } else {
-          return py::buffer_info(
-              buffer_ptr,        /* Pointer to buffer */
-              sizeof(ValueType), /* Size of one scalar */
-              py::format_descriptor<ValueType>::format(), /* Python
-                                                          struct-style
-                                                          format
-                                                          descriptor */
-              dim,          /* Number of dimensions */
-              {rows, cols}, /* Buffer dimensions */
-              {sizeof(ValueType), sizeof(ValueType) * rows}
-              /* Strides (in bytes) for each index */
-          );
-        }
-      })
-      .def(
-          "apply",
-          [](const gko::matrix::Dense<ValueType> &d,
-             std::shared_ptr<const gko::LinOp> b,
-             std::shared_ptr<gko::LinOp> x) { d.apply(b, x); },
-          "")
-      .def("scale",
-           [](gko::matrix::Dense<ValueType> &m, ValueType s) {
-             auto o = gko::matrix::Dense<ValueType>::create(m.get_executor(),
-                                                            gko::dim<2>(1, 1));
-             o->fill(s);
-             m.scale(o);
-           })
-      .def("inv_scale",
-           [](gko::matrix::Dense<ValueType> &m, ValueType s) {
-             auto o = gko::matrix::Dense<ValueType>::create(m.get_executor(),
-                                                            gko::dim<2>(1, 1));
-             o->fill(s);
-             m.inv_scale(o);
-           })
-      .def("add_scaled", &gko::matrix::Dense<ValueType>::add_scaled,
-           "Adds `b` scaled by `alpha` to the matrix (aka: BLAS axpy).")
-      .def("sub_scaled", &gko::matrix::Dense<ValueType>::sub_scaled,
-           "Subtracts `b` scaled by `alpha` from the matrix (aka: BLAS axpy).")
-      .def("at",
-           py::overload_cast<size_t>(&gko::matrix::Dense<ValueType>::at,
-                                     py::const_),
-           "Returns an element using linearized index.")
-      .def("at",
-           py::overload_cast<size_t, size_t>(&gko::matrix::Dense<ValueType>::at,
-                                             py::const_),
-           "Returns an element at row, column index.")
-      .def("get_num_stored_elements",
-           &gko::matrix::Dense<ValueType>::get_num_stored_elements,
-           "Returns the number of elements explicitly stored in the "
-           "matrix.");
+            if (dim == 1) {
+                return py::buffer_info(
+                    buffer_ptr,        /* Pointer to buffer */
+                    sizeof(ValueType), /* Size of one scalar */
+                    py::format_descriptor<ValueType>::format(), /* Python
+                                                                struct-style
+                                                                format
+                                                                descriptor */
+                    dim,                /* Number of dimensions */
+                    {rows},             /* Buffer dimensions */
+                    {sizeof(ValueType)} /* Strides (in bytes) for each index */
+                );
+            } else {
+                return py::buffer_info(
+                    buffer_ptr,        /* Pointer to buffer */
+                    sizeof(ValueType), /* Size of one scalar */
+                    py::format_descriptor<ValueType>::format(), /* Python
+                                                                struct-style
+                                                                format
+                                                                descriptor */
+                    dim,          /* Number of dimensions */
+                    {rows, cols}, /* Buffer dimensions */
+                    {sizeof(ValueType), sizeof(ValueType) * rows}
+                    /* Strides (in bytes) for each index */
+                );
+            }
+        })
+        .def(
+            "apply",
+            [](const gko::matrix::Dense<ValueType> &d,
+               std::shared_ptr<const gko::LinOp> b,
+               std::shared_ptr<gko::LinOp> x) { d.apply(b, x); },
+            "")
+        .def("scale",
+             [](gko::matrix::Dense<ValueType> &m, ValueType s) {
+                 auto o = gko::matrix::Dense<ValueType>::create(
+                     m.get_executor(), gko::dim<2>(1, 1));
+                 o->fill(s);
+                 m.scale(o);
+             })
+        .def("inv_scale",
+             [](gko::matrix::Dense<ValueType> &m, ValueType s) {
+                 auto o = gko::matrix::Dense<ValueType>::create(
+                     m.get_executor(), gko::dim<2>(1, 1));
+                 o->fill(s);
+                 m.inv_scale(o);
+             })
+        .def("add_scaled", &gko::matrix::Dense<ValueType>::add_scaled,
+             "Adds `b` scaled by `alpha` to the matrix (aka: BLAS axpy).")
+        .def(
+            "sub_scaled", &gko::matrix::Dense<ValueType>::sub_scaled,
+            "Subtracts `b` scaled by `alpha` from the matrix (aka: BLAS axpy).")
+        .def("at",
+             py::overload_cast<size_t>(&gko::matrix::Dense<ValueType>::at,
+                                       py::const_),
+             "Returns an element using linearized index.")
+        .def("at",
+             py::overload_cast<size_t, size_t>(
+                 &gko::matrix::Dense<ValueType>::at, py::const_),
+             "Returns an element at row, column index.")
+        .def("get_num_stored_elements",
+             &gko::matrix::Dense<ValueType>::get_num_stored_elements,
+             "Returns the number of elements explicitly stored in the "
+             "matrix.");
 }

--- a/src/executor.cpp
+++ b/src/executor.cpp
@@ -8,53 +8,54 @@
 
 namespace py = pybind11;
 
-void add_executor_classes(py::module_ &root_module) {
-  py::class_<gko::Executor, std::shared_ptr<gko::Executor>>(root_module,
-                                                            "Executor");
+void add_executor_classes(py::module_ &root_module)
+{
+    py::class_<gko::Executor, std::shared_ptr<gko::Executor>>(root_module,
+                                                              "Executor");
 
-  // CPU executors
-  py::class_<gko::detail::ExecutorBase<gko::OmpExecutor>, gko::Executor,
-             std::shared_ptr<gko::detail::ExecutorBase<gko::OmpExecutor>>>(
-      root_module, "OmpExecutorBase");
+    // CPU executors
+    py::class_<gko::detail::ExecutorBase<gko::OmpExecutor>, gko::Executor,
+               std::shared_ptr<gko::detail::ExecutorBase<gko::OmpExecutor>>>(
+        root_module, "OmpExecutorBase");
 
-  py::class_<gko::OmpExecutor, gko::detail::ExecutorBase<gko::OmpExecutor>,
-             std::shared_ptr<gko::OmpExecutor>>(root_module, "OmpExecutor")
-      .def(py::init([]() { return gko::OmpExecutor::create(); }));
+    py::class_<gko::OmpExecutor, gko::detail::ExecutorBase<gko::OmpExecutor>,
+               std::shared_ptr<gko::OmpExecutor>>(root_module, "OmpExecutor")
+        .def(py::init([]() { return gko::OmpExecutor::create(); }));
 
-  py::class_<gko::ReferenceExecutor, gko::OmpExecutor,
-             std::shared_ptr<gko::ReferenceExecutor>>(root_module,
-                                                      "ReferenceExecutor")
-      .def(py::init([]() { return gko::ReferenceExecutor::create(); }));
+    py::class_<gko::ReferenceExecutor, gko::OmpExecutor,
+               std::shared_ptr<gko::ReferenceExecutor>>(root_module,
+                                                        "ReferenceExecutor")
+        .def(py::init([]() { return gko::ReferenceExecutor::create(); }));
 
 // GPU executors
 #ifdef GINKGO_BUILD_CUDA
-  py::class_<gko::detail::ExecutorBase<gko::CudaExecutor>, gko::Executor,
-             std::shared_ptr<gko::detail::ExecutorBase<gko::CudaExecutor>>>(
-      root_module, "CudaExecutorBase");
+    py::class_<gko::detail::ExecutorBase<gko::CudaExecutor>, gko::Executor,
+               std::shared_ptr<gko::detail::ExecutorBase<gko::CudaExecutor>>>(
+        root_module, "CudaExecutorBase");
 
-  py::class_<gko::CudaExecutor, gko::detail::ExecutorBase<gko::CudaExecutor>,
-             std::shared_ptr<gko::CudaExecutor>>(root_module, "CudaExecutor")
-      .def(py::init([](int dev_id, std::shared_ptr<gko::Executor> master,
-                       std::shared_ptr<gko::CudaAllocatorBase> alloc,
-                       std::shared_ptr<gko::cuda_stream> stream) {
-             return gko::CudaExecutor::create(dev_id, master, alloc,
-                                              stream->get());
-           }),
-           // The first two are the deviation from the original library
-           py::arg("device_id") = 0,
-           py::arg("master") = gko::ReferenceExecutor::create(),
-           py::arg("allocator") = std::make_shared<gko::CudaAllocator>(),
-           py::arg("stream") = std::make_shared<gko::cuda_stream>())
+    py::class_<gko::CudaExecutor, gko::detail::ExecutorBase<gko::CudaExecutor>,
+               std::shared_ptr<gko::CudaExecutor>>(root_module, "CudaExecutor")
+        .def(py::init([](int dev_id, std::shared_ptr<gko::Executor> master,
+                         std::shared_ptr<gko::CudaAllocatorBase> alloc,
+                         std::shared_ptr<gko::cuda_stream> stream) {
+                 return gko::CudaExecutor::create(dev_id, master, alloc,
+                                                  stream->get());
+             }),
+             // The first two are the deviation from the original library
+             py::arg("device_id") = 0,
+             py::arg("master") = gko::ReferenceExecutor::create(),
+             py::arg("allocator") = std::make_shared<gko::CudaAllocator>(),
+             py::arg("stream") = std::make_shared<gko::cuda_stream>())
 
-      .def_property_readonly(
-          "master",
-          [](std::shared_ptr<gko::CudaExecutor> self)
-              -> std::shared_ptr<gko::Executor>
-          // Hopefully there would be no problems with converting val to lval
-          { return self->get_master(); })
+        .def_property_readonly(
+            "master",
+            [](std::shared_ptr<gko::CudaExecutor> self)
+                -> std::shared_ptr<gko::Executor>
+            // Hopefully there would be no problems with converting val to lval
+            { return self->get_master(); })
 
-      .def_property_readonly("device_id", &gko::CudaExecutor::get_device_id)
+        .def_property_readonly("device_id", &gko::CudaExecutor::get_device_id)
 
-      .def_static("get_num_devices", &gko::CudaExecutor::get_num_devices);
+        .def_static("get_num_devices", &gko::CudaExecutor::get_num_devices);
 #endif
 }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -7,87 +7,95 @@
 namespace py = pybind11;
 
 #define GKO_MATRIX_BINDING(Name)                                               \
-  py::class_<gko::matrix::Name<ValueType>,                                     \
-             std::shared_ptr<gko::matrix::Name<ValueType>>, gko::LinOp>(       \
-      module_matrix, #Name, py::buffer_protocol())                             \
-      .def(py::init([](std::shared_ptr<gko::Executor> exec) {                  \
-        return gko::matrix::Name<ValueType>::create(exec);                     \
-      }))                                                                      \
-      .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,     \
-                       gko::array<ValueType> &vals,                            \
-                       gko::array<IndexType> &cols,                            \
-                       gko::array<IndexType> &rows) {                          \
-        return gko::share(gko::matrix::Name<ValueType>::create(                \
-            exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},   \
-            vals, cols, rows));                                                \
-      }))                                                                      \
-      .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,     \
-                       py::buffer data, py::buffer rows, py::buffer cols) {    \
-        /* Request a buffer descriptor from Python */                          \
-        py::buffer_info data_info = data.request();                            \
-        py::buffer_info rows_info = rows.request();                            \
-        py::buffer_info cols_info = cols.request();                            \
+    py::class_<gko::matrix::Name<ValueType>,                                   \
+               std::shared_ptr<gko::matrix::Name<ValueType>>, gko::LinOp>(     \
+        module_matrix, #Name, py::buffer_protocol())                           \
+        .def(py::init([](std::shared_ptr<gko::Executor> exec) {                \
+            return gko::matrix::Name<ValueType>::create(exec);                 \
+        }))                                                                    \
+        .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,   \
+                         gko::array<ValueType> &vals,                          \
+                         gko::array<IndexType> &cols,                          \
+                         gko::array<IndexType> &rows) {                        \
+            return gko::share(gko::matrix::Name<ValueType>::create(            \
+                exec,                                                          \
+                gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},     \
+                vals, cols, rows));                                            \
+        }))                                                                    \
+        .def(py::init([](std::shared_ptr<gko::Executor> exec, py::tuple dim,   \
+                         py::buffer data, py::buffer rows, py::buffer cols) {  \
+            /* Request a buffer descriptor from Python */                      \
+            py::buffer_info data_info = data.request();                        \
+            py::buffer_info rows_info = rows.request();                        \
+            py::buffer_info cols_info = cols.request();                        \
                                                                                \
-        if (data_info.format != py::format_descriptor<ValueType>::format())    \
-          throw std::runtime_error(                                            \
-              "Provided values have an incompatible dtype");                   \
+            if (data_info.format !=                                            \
+                py::format_descriptor<ValueType>::format())                    \
+                throw std::runtime_error(                                      \
+                    "Provided values have an incompatible dtype");             \
                                                                                \
-        if (rows_info.format != py::format_descriptor<IndexType>::format())    \
-          throw std::runtime_error(                                            \
-              "Provided rows have an incompatible dtype");                     \
+            if (rows_info.format !=                                            \
+                py::format_descriptor<IndexType>::format())                    \
+                throw std::runtime_error(                                      \
+                    "Provided rows have an incompatible dtype");               \
                                                                                \
-        if (cols_info.format != py::format_descriptor<IndexType>::format())    \
-          throw std::runtime_error(                                            \
-              "Provided cols have an incompatible dtype");                     \
+            if (cols_info.format !=                                            \
+                py::format_descriptor<IndexType>::format())                    \
+                throw std::runtime_error(                                      \
+                    "Provided cols have an incompatible dtype");               \
                                                                                \
-        auto ref = gko::ReferenceExecutor::create();                           \
+            auto ref = gko::ReferenceExecutor::create();                       \
                                                                                \
-        /* create a view into numpy data */                                    \
-        auto nnz = data_info.shape[0];                                         \
+            /* create a view into numpy data */                                \
+            auto nnz = data_info.shape[0];                                     \
                                                                                \
-        auto data_view =                                                       \
-            gko::array<ValueType>::view(ref, nnz, (ValueType *)data_info.ptr); \
-        auto rows_view =                                                       \
-            gko::array<IndexType>::view(ref, nnz, (IndexType *)rows_info.ptr); \
-        auto cols_view =                                                       \
-            gko::array<IndexType>::view(ref, nnz, (IndexType *)cols_info.ptr); \
+            auto data_view = gko::array<ValueType>::view(                      \
+                ref, nnz, (ValueType *)data_info.ptr);                         \
+            auto rows_view = gko::array<IndexType>::view(                      \
+                ref, nnz, (IndexType *)rows_info.ptr);                         \
+            auto cols_view = gko::array<IndexType>::view(                      \
+                ref, nnz, (IndexType *)cols_info.ptr);                         \
                                                                                \
-        return gko::share(gko::matrix::Name<ValueType>::create(                \
-            exec, gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},   \
-            data_view, cols_view, rows_view));                                 \
-      }))                                                                      \
-      .def(                                                                    \
-          "apply",                                                             \
-          [](const gko::matrix::Name<ValueType, IndexType> &m,                 \
-             std::shared_ptr<const gko::LinOp> b,                              \
-             std::shared_ptr<gko::LinOp> x) { m.apply(b, x); },                \
-          "")                                                                  \
-      .def("__repr__",                                                         \
-           [](const gko::matrix::Name<ValueType> &o) {                         \
-             auto str = std::string("pygko.matrix.Name object");               \
-             return str;                                                       \
-           })                                                                  \
-      .def("get_num_stored_elements",                                          \
-           &gko::matrix::Name<ValueType>::get_num_stored_elements,             \
-           "Applies Name matrix axpy to a vector (or a sequence of vectors)."  \
-           "Performs the operation x = Name * b + x")
+            return gko::share(gko::matrix::Name<ValueType>::create(            \
+                exec,                                                          \
+                gko::dim<2>{dim[0].cast<size_t>(), dim[1].cast<size_t>()},     \
+                data_view, cols_view, rows_view));                             \
+        }))                                                                    \
+        .def(                                                                  \
+            "apply",                                                           \
+            [](const gko::matrix::Name<ValueType, IndexType> &m,               \
+               std::shared_ptr<const gko::LinOp> b,                            \
+               std::shared_ptr<gko::LinOp> x) { m.apply(b, x); },              \
+            "")                                                                \
+        .def("__repr__",                                                       \
+             [](const gko::matrix::Name<ValueType> &o) {                       \
+                 auto str = std::string("pygko.matrix.Name object");           \
+                 return str;                                                   \
+             })                                                                \
+        .def(                                                                  \
+            "get_num_stored_elements",                                         \
+            &gko::matrix::Name<ValueType>::get_num_stored_elements,            \
+            "Applies Name matrix axpy to a vector (or a sequence of vectors)." \
+            "Performs the operation x = Name * b + x")
 
-void init_coo(py::module_ &module_matrix) {
-  module_matrix.def("read_Coo", [](const std::string &fn,
-                                   std::shared_ptr<gko::Executor> exec) {
-    return gko::share(
-        gko::read<gko::matrix::Coo<ValueType>>(std::ifstream(fn), exec));
-  });
+void init_coo(py::module_ &module_matrix)
+{
+    module_matrix.def("read_Coo", [](const std::string &fn,
+                                     std::shared_ptr<gko::Executor> exec) {
+        return gko::share(
+            gko::read<gko::matrix::Coo<ValueType>>(std::ifstream(fn), exec));
+    });
 
-  GKO_MATRIX_BINDING(Coo);
+    GKO_MATRIX_BINDING(Coo);
 }
 
-void init_csr(py::module_ &module_matrix) {
-  module_matrix.def("read_Csr", [](const std::string &fn,
-                                   std::shared_ptr<gko::Executor> exec) {
-    return gko::share(
-        gko::read<gko::matrix::Csr<ValueType>>(std::ifstream(fn), exec));
-  });
+void init_csr(py::module_ &module_matrix)
+{
+    module_matrix.def("read_Csr", [](const std::string &fn,
+                                     std::shared_ptr<gko::Executor> exec) {
+        return gko::share(
+            gko::read<gko::matrix::Csr<ValueType>>(std::ifstream(fn), exec));
+    });
 
-  GKO_MATRIX_BINDING(Csr);
+    GKO_MATRIX_BINDING(Csr);
 }

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -9,19 +9,21 @@
 
 namespace py = pybind11;
 
-void add_allocator_classes(py::module_ &root_module) {
-  py::class_<gko::Allocator, std::shared_ptr<gko::Allocator>>(root_module,
-                                                              "Allocator");
+void add_allocator_classes(py::module_ &root_module)
+{
+    py::class_<gko::Allocator, std::shared_ptr<gko::Allocator>>(root_module,
+                                                                "Allocator");
 
 #ifdef GINKGO_BUILD_CUDA
-  // TODO: implement CudaAllocatorBase binding,
-  //    to be able to define custom allocator
-  py::class_<gko::CudaAllocatorBase, gko::Allocator,
-             std::shared_ptr<gko::CudaAllocatorBase>>(root_module,
-                                                      "CudaAllocatorBase");
+    // TODO: implement CudaAllocatorBase binding,
+    //    to be able to define custom allocator
+    py::class_<gko::CudaAllocatorBase, gko::Allocator,
+               std::shared_ptr<gko::CudaAllocatorBase>>(root_module,
+                                                        "CudaAllocatorBase");
 
-  py::class_<gko::CudaAllocator, gko::CudaAllocatorBase,
-             std::shared_ptr<gko::CudaAllocator>>(root_module, "CudaAllocator")
-      .def(py::init());
+    py::class_<gko::CudaAllocator, gko::CudaAllocatorBase,
+               std::shared_ptr<gko::CudaAllocator>>(root_module,
+                                                    "CudaAllocator")
+        .def(py::init());
 #endif
 }

--- a/src/python.cpp
+++ b/src/python.cpp
@@ -14,28 +14,29 @@ void add_allocator_classes(py::module_ &);
 void add_stream_classes(py::module_ &);
 void add_executor_classes(py::module_ &);
 
-PYBIND11_MODULE(pyGinkgo, m) {
-  m.doc() = "Python bindings for the Ginkgo framework";
+PYBIND11_MODULE(pyGinkgo, m)
+{
+    m.doc() = "Python bindings for the Ginkgo framework";
 
-  py::class_<gko::LinOp, std::shared_ptr<gko::LinOp>>(m, "LinOp");
+    py::class_<gko::LinOp, std::shared_ptr<gko::LinOp>>(m, "LinOp");
 
-  py::class_<gko::ptr_param<gko::LinOp>>(m, "ptr_param");
+    py::class_<gko::ptr_param<gko::LinOp>>(m, "ptr_param");
 
-  py::class_<gko::dim<2>>(m, "dim2").def(
-      py::init<unsigned long, unsigned long>());
+    py::class_<gko::dim<2>>(m, "dim2").def(
+        py::init<unsigned long, unsigned long>());
 
-  add_allocator_classes(m);
-  add_stream_classes(m);
-  add_executor_classes(m);
+    add_allocator_classes(m);
+    add_stream_classes(m);
+    add_executor_classes(m);
 
-  py::module_ module_base =
-      m.def_submodule("base", "Submodule for Ginkgos low level type bindings");
-  init_array(module_base);
+    py::module_ module_base = m.def_submodule(
+        "base", "Submodule for Ginkgos low level type bindings");
+    init_array(module_base);
 
-  py::module_ module_matrix =
-      m.def_submodule("matrix", "Submodule for Ginkgos matrix type bindings");
+    py::module_ module_matrix =
+        m.def_submodule("matrix", "Submodule for Ginkgos matrix type bindings");
 
-  init_dense(module_matrix);
-  init_coo(module_matrix);
-  init_csr(module_matrix);
+    init_dense(module_matrix);
+    init_coo(module_matrix);
+    init_csr(module_matrix);
 }

--- a/src/stream.cpp
+++ b/src/stream.cpp
@@ -8,15 +8,17 @@
 
 namespace py = pybind11;
 
-void add_stream_classes(py::module_ &root_module) {
+void add_stream_classes(py::module_ &root_module)
+{
 #ifdef GINKGO_BUILD_CUDA
-  py::class_<gko::cuda_stream, std::shared_ptr<gko::cuda_stream>>(root_module,
-                                                                  "cuda_stream")
-      // The comments are copied from the source of the class at
-      // ginkgo-src/include/ginkgo/core/base/stream.hpp
-      .def(py::init(),
-           "Creates an empty stream wrapper, representing the default stream.")
-      .def(py::init<int>(),
-           "Creates a new custom CUDA stream on the given CUDA device ID");
+    py::class_<gko::cuda_stream, std::shared_ptr<gko::cuda_stream>>(
+        root_module, "cuda_stream")
+        // The comments are copied from the source of the class at
+        // ginkgo-src/include/ginkgo/core/base/stream.hpp
+        .def(
+            py::init(),
+            "Creates an empty stream wrapper, representing the default stream.")
+        .def(py::init<int>(),
+             "Creates a new custom CUDA stream on the given CUDA device ID");
 #endif
 }


### PR DESCRIPTION
This PR adds a clang-format file for consistent cpp file formatting. Additionally, I set the indentation width to 2 since that was requested in our last meeting. I am open for any further modifications.