### PR TITLE
Fix find_package case for pre-installed Ginkgo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,8 +182,8 @@ endif()
 set(CMAKE_INSTALL_RPATH ${Python_SITELIB}/${PROJECT_NAME})
 
 message(STATUS "Install path: ${Python_SITELIB}")
-install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-        DESTINATION ${Python_SITELIB})
+install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/
+        DESTINATION ${PY_BUILD_CMAKE_MODULE_NAME})
 if(NOT Ginkgo_FOUND)
   # Only install Ginkgo shared libraries when built from source (FetchContent).
   # When using a pre-installed Ginkgo (e.g. conda), its libraries are already available.
@@ -197,5 +197,5 @@ if(NOT Ginkgo_FOUND)
     ginkgo_dpcpp
     ginkgo_reference
     DESTINATION
-    ${Python_SITELIB}/${PROJECT_NAME})
+    ${PY_BUILD_CMAKE_MODULE_NAME})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT nlohmann_json_FOUND)
   FetchContent_MakeAvailable(nlohmann_json)
 endif()
 
-# Find  Ginkgo find_package(Ginkgo 1.7.0 QUIET)
+# Find Ginkgo (quietly; no minimum version specified)
 find_package(Ginkgo QUIET)
 
 # Fetch Ginkgo if not found

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,10 @@ if(NOT nlohmann_json_FOUND)
 endif()
 
 # Find  Ginkgo find_package(Ginkgo 1.7.0 QUIET)
-find_package(ginkgo QUIET)
+find_package(Ginkgo QUIET)
 
 # Fetch Ginkgo if not found
-if(NOT ginkgo_FOUND)
+if(NOT Ginkgo_FOUND)
   # If not found, fetch Ginkgo
   include(FetchContent)
   if(NOT DEFINED GINKGO_BUILD_TESTS)
@@ -184,14 +184,18 @@ set(CMAKE_INSTALL_RPATH ${Python_SITELIB}/${PROJECT_NAME})
 message(STATUS "Install path: ${Python_SITELIB}")
 install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
         DESTINATION ${Python_SITELIB})
-install(
-  IMPORTED_RUNTIME_ARTIFACTS
-  ginkgo
-  ginkgo_device
-  ginkgo_hip
-  ginkgo_cuda
-  ginkgo_omp
-  ginkgo_dpcpp
-  ginkgo_reference
-  DESTINATION
-  ${Python_SITELIB}/${PROJECT_NAME})
+if(NOT Ginkgo_FOUND)
+  # Only install Ginkgo shared libraries when built from source (FetchContent).
+  # When using a pre-installed Ginkgo (e.g. conda), its libraries are already available.
+  install(
+    IMPORTED_RUNTIME_ARTIFACTS
+    ginkgo
+    ginkgo_device
+    ginkgo_hip
+    ginkgo_cuda
+    ginkgo_omp
+    ginkgo_dpcpp
+    ginkgo_reference
+    DESTINATION
+    ${Python_SITELIB}/${PROJECT_NAME})
+endif()


### PR DESCRIPTION
## Problem

Two CMake issues prevented using a pre-installed Ginkgo (e.g. from conda) and broke wheel packaging:

1. **Case mismatch in `find_package`:** `find_package(ginkgo QUIET)` (lowercase) fails to find a pre-installed Ginkgo on case-sensitive filesystems (Linux). Ginkgo upstream installs its CMake config as `GinkgoConfig.cmake` in `lib/cmake/Ginkgo/`, but CMake's `find_package(ginkgo)` searches for `ginkgoConfig.cmake` — a case mismatch.

2. **Absolute install destination breaks wheel packaging:** `install(DIRECTORY ... DESTINATION ${Python_SITELIB})` used an absolute path, which bypasses `CMAKE_INSTALL_PREFIX`. Since py-build-cmake uses a staging directory as the install prefix to collect files for the wheel, the absolute destination wrote files directly to site-packages — the compiled `.so` binding was never included in the wheel.

Additionally, `install(IMPORTED_RUNTIME_ARTIFACTS ginkgo ...)` references bare targets that only exist when Ginkgo is built from source via FetchContent. When using a pre-installed Ginkgo, these targets don't exist and the build fails.

## Changes

- **`find_package(Ginkgo QUIET)`** instead of `find_package(ginkgo QUIET)` to match `GinkgoConfig.cmake`
- **Guard `install(IMPORTED_RUNTIME_ARTIFACTS ...)`** with `if(NOT Ginkgo_FOUND)` — Ginkgo shared libraries only need to be bundled when built from source
- **Use relative `DESTINATION`** (`${PY_BUILD_CMAKE_MODULE_NAME}`) instead of absolute `${Python_SITELIB}` so files are installed into the staging area where py-build-cmake picks them up for the wheel
- **Add trailing `/`** to source `DIRECTORY` to install contents, not the directory itself (avoids `pyGinkgo/pyGinkgo/` nesting)

## Testing

Verified that:
- `pip wheel .` produces a wheel containing the compiled `.so` binding (~823KB vs 12KB before)
- `pip install <wheel>` followed by `import pyGinkgo` succeeds
- Ginkgo is found from conda without triggering FetchContent