### PR TITLE
refactor: unify CuPy/buffer-protocol path for array and sparse Csr

### DIFF
--- a/src/cpp_bindings/array.cpp
+++ b/src/cpp_bindings/array.cpp
@@ -20,77 +20,7 @@ void init_array(py::module_ &module, const std::string typestr)
                           gko::array<ValueType> &>())
             .def(py::init([](std::shared_ptr<gko::Executor> exec,
                              py::object obj) {
-#ifdef GINKGO_BUILD_CUDA
-                     // Fast path: if the input exposes
-                     // __cuda_array_interface__ and the executor is a
-                     // CUDA executor, create a zero-copy view instead
-                     // of going through host memory.
-                     // py::keep_alive<1,3> ensures the source object
-                     // stays alive while this array exists.
-                     if (py::hasattr(obj, "__cuda_array_interface__") &&
-                         std::dynamic_pointer_cast<const gko::CudaExecutor>(
-                             exec)) {
-                         auto cai = obj.attr("__cuda_array_interface__")
-                                        .cast<py::dict>();
-                         auto shape = cai["shape"].cast<py::tuple>();
-                         if (py::len(shape) != 1) {
-                             throw std::runtime_error(
-                                 "Only 1D arrays are supported");
-                         }
-                         auto typestr = cai["typestr"].cast<std::string>();
-                         auto expected = get_cuda_array_typestr<ValueType>();
-                         if (typestr != expected) {
-                             throw std::runtime_error(
-                                 "dtype mismatch: "
-                                 "__cuda_array_interface__ reports '" +
-                                 typestr + "' but this array type expects '" +
-                                 expected + "'");
-                         }
-                         // Validate contiguous storage: strides must be
-                         // None or a 1-element tuple equal to sizeof(T)
-                         if (cai.contains("strides")) {
-                             py::handle strides_obj = cai["strides"];
-                             if (!strides_obj.is_none()) {
-                                 auto strides = strides_obj.cast<py::tuple>();
-                                 if (strides.size() != 1) {
-                                     throw std::runtime_error(
-                                         "__cuda_array_interface__ "
-                                         "'strides' must describe a "
-                                         "1D array");
-                                 }
-                                 auto stride0 = strides[0].cast<ssize_t>();
-                                 if (stride0 !=
-                                     static_cast<ssize_t>(sizeof(ValueType))) {
-                                     throw std::runtime_error(
-                                         "__cuda_array_interface__ "
-                                         "object must be 1D and "
-                                         "contiguous in memory");
-                                 }
-                             }
-                         }
-                         auto data = cai["data"].cast<py::tuple>();
-                         auto ptr = data[0].cast<uintptr_t>();
-                         auto size = shape[0].cast<size_t>();
-                         return gko::array<ValueType>::view(
-                             exec, size, reinterpret_cast<ValueType *>(ptr));
-                     }
-#endif
-                     // Fallback: use buffer protocol (host memory)
-                     auto b =
-                         py::array_t<ValueType, py::array::c_style |
-                                                    py::array::forcecast>(obj);
-                     py::buffer_info info = b.request();
-                     check_buffer_dtype<ValueType>(info);
-
-                     if (info.ndim != 1) {
-                         throw std::runtime_error(
-                             "Only 1D arrays are supported");
-                     }
-
-                     auto elems = info.shape[0];
-                     return gko::array<ValueType>(
-                         exec, (ValueType *)info.ptr,
-                         (ValueType *)info.ptr + elems);
+                     return gko_array_from_pyobject<ValueType>(exec, obj);
                  }),
                  py::keep_alive<1, 3>())
             .def_buffer([](gko::array<ValueType> &a) -> py::buffer_info {

--- a/src/cpp_bindings/matrix.cpp
+++ b/src/cpp_bindings/matrix.cpp
@@ -130,7 +130,7 @@ void init_matrix(py::module_ &module, const std::string matrix_type,
                     auto rows = shape_t[0].cast<size_t>();
                     auto cols = shape_t[1].cast<size_t>();
 
-                    auto data_obj = obj.attr("data");
+                    py::object data_obj = obj.attr("data");
                     py::object col_obj;
                     py::object row_obj;
 
@@ -158,85 +158,17 @@ void init_matrix(py::module_ &module, const std::string matrix_type,
                         row_obj = obj.attr("row");
                     }
 
-#ifdef GINKGO_BUILD_CUDA
-                    if (py::hasattr(data_obj,
-                                    "__cuda_array_interface__") &&
-                        std::dynamic_pointer_cast<
-                            const gko::CudaExecutor>(exec)) {
-                        // Validate dtypes before creating views to
-                        // avoid silent memory reinterpretation.
-                        auto expected_val =
-                            get_cuda_array_typestr<ValueType>();
-                        auto expected_idx =
-                            get_cuda_array_typestr<IndexType>();
-                        auto check_typestr = [](py::object arr,
-                                                const std::string &expected,
-                                                const char *name) {
-                            auto cai =
-                                arr.attr("__cuda_array_interface__")
-                                    .cast<py::dict>();
-                            auto typestr =
-                                cai["typestr"].cast<std::string>();
-                            if (typestr != expected) {
-                                throw std::runtime_error(
-                                    std::string("dtype mismatch for ") +
-                                    name +
-                                    ": __cuda_array_interface__ reports '" +
-                                    typestr + "' but expected '" +
-                                    expected + "'");
-                            }
-                        };
-                        check_typestr(data_obj, expected_val, "data");
-                        check_typestr(col_obj, expected_idx, "col_idxs");
-                        check_typestr(row_obj, expected_idx, "row_component");
-                        auto [vals_ptr, nnz] =
-                            cai_ptr_and_size<ValueType>(data_obj);
-                        auto [cols_ptr, cols_n] =
-                            cai_ptr_and_size<IndexType>(col_obj);
-                        auto [rows_ptr, rows_n] =
-                            cai_ptr_and_size<IndexType>(row_obj);
-
-                        return gko::share(
-                            MatrixType<ValueType, IndexType>::create(
-                                exec, gko::dim<2>{rows, cols},
-                                gko::array<ValueType>::view(
-                                    exec, nnz, vals_ptr),
-                                gko::array<IndexType>::view(
-                                    exec, cols_n, cols_ptr),
-                                gko::array<IndexType>::view(
-                                    exec, rows_n, rows_ptr)));
-                    }
-#endif
-                    // Fallback: copy via buffer protocol
-                    auto data_buf =
-                        py::array_t<ValueType,
-                                    py::array::c_style |
-                                        py::array::forcecast>(data_obj);
-                    auto cols_buf =
-                        py::array_t<IndexType,
-                                    py::array::c_style |
-                                        py::array::forcecast>(col_obj);
-                    auto rows_buf =
-                        py::array_t<IndexType,
-                                    py::array::c_style |
-                                        py::array::forcecast>(row_obj);
-
-                    auto ref = gko::ReferenceExecutor::create();
-                    py::buffer_info di = data_buf.request();
-                    py::buffer_info ci = cols_buf.request();
-                    py::buffer_info ri = rows_buf.request();
-
-                    auto dv = gko::array<ValueType>::view(
-                        ref, di.shape[0], (ValueType *)di.ptr);
-                    auto cv = gko::array<IndexType>::view(
-                        ref, ci.shape[0], (IndexType *)ci.ptr);
-                    auto rv = gko::array<IndexType>::view(
-                        ref, ri.shape[0], (IndexType *)ri.ptr);
+                    auto data_arr =
+                        gko_array_from_pyobject<ValueType>(exec, data_obj);
+                    auto col_arr =
+                        gko_array_from_pyobject<IndexType>(exec, col_obj);
+                    auto row_arr =
+                        gko_array_from_pyobject<IndexType>(exec, row_obj);
 
                     return gko::share(
                         MatrixType<ValueType, IndexType>::create(
                             exec, gko::dim<2>{rows, cols},
-                            dv, cv, rv));
+                            data_arr, col_arr, row_arr));
                 }),
                 py::keep_alive<1, 3>())
             .def("__repr__",

--- a/src/cpp_bindings/utils.hpp
+++ b/src/cpp_bindings/utils.hpp
@@ -33,6 +33,72 @@ std::string get_cuda_array_typestr()
 }
 
 /**
+ * Create a gko::array<T> from a Python object.
+ *
+ * CUDA executor + __cuda_array_interface__: zero-copy device view.
+ * Otherwise: copy via buffer protocol (host memory).
+ *
+ * This is the single source of truth for the "py::object → gko::array"
+ * conversion used by the array, CSR, and COO pybind11 constructors.
+ */
+template <typename T>
+gko::array<T> gko_array_from_pyobject(std::shared_ptr<gko::Executor> exec,
+                                      py::object obj)
+{
+#ifdef GINKGO_BUILD_CUDA
+    if (py::hasattr(obj, "__cuda_array_interface__") &&
+        std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
+        auto cai = obj.attr("__cuda_array_interface__").cast<py::dict>();
+        auto shape = cai["shape"].cast<py::tuple>();
+        if (py::len(shape) != 1) {
+            throw std::runtime_error(
+                "__cuda_array_interface__ object must be 1D (got " +
+                std::to_string(py::len(shape)) + " dimensions)");
+        }
+
+        auto typestr = cai["typestr"].cast<std::string>();
+        auto expected = get_cuda_array_typestr<T>();
+        if (typestr != expected) {
+            throw std::runtime_error(
+                "dtype mismatch: __cuda_array_interface__ reports '" +
+                typestr + "' but expected '" + expected + "'");
+        }
+
+        // Validate contiguous storage: strides must be None or sizeof(T).
+        if (cai.contains("strides")) {
+            py::handle strides_obj = cai["strides"];
+            if (!strides_obj.is_none()) {
+                auto strides = strides_obj.cast<py::tuple>();
+                if (strides.size() != 1 ||
+                    strides[0].cast<ssize_t>() !=
+                        static_cast<ssize_t>(sizeof(T))) {
+                    throw std::runtime_error(
+                        "__cuda_array_interface__ object must be 1D and "
+                        "contiguous in memory");
+                }
+            }
+        }
+
+        auto data = cai["data"].cast<py::tuple>();
+        auto ptr = data[0].cast<uintptr_t>();
+        auto size = shape[0].cast<size_t>();
+        return gko::array<T>::view(exec, size, reinterpret_cast<T *>(ptr));
+    }
+#endif
+    // Fallback: copy via buffer protocol (host memory)
+    auto buf =
+        py::array_t<T, py::array::c_style | py::array::forcecast>(obj);
+    py::buffer_info info = buf.request();
+    check_buffer_dtype<T>(info);
+    if (info.ndim != 1) {
+        throw std::runtime_error("Only 1D arrays are supported");
+    }
+    auto elems = info.shape[0];
+    return gko::array<T>(exec, (T *)info.ptr, (T *)info.ptr + elems);
+}
+
+
+/**
  * Instantiates a template for each non-complex value type compiled by Ginkgo.
  *
  * @param _macro  A macro which expands the template instantiation


### PR DESCRIPTION
# PR-A: refactor: unify CuPy/buffer-protocol path for `array` and sparse `Csr`

**Branch (fork):** `rho-novatron:refactor/array-helper`
**Base (upstream):** `Helmholtz-AI-Energy:main`
**Commits:** 1 (`17b586d`)

---

## Summary

Pulls the `__cuda_array_interface__` / Python-buffer-protocol input
handling out of `array.cpp` and `matrix.cpp` and into a single helper
in `utils.hpp`:

```cpp
template <typename T>
gko::array<T> gko_array_from_pyobject(
    std::shared_ptr<const gko::Executor> exec,
    py::object obj);
```

Both the `gko::array(Executor, py::object)` constructor and the
sparse `Csr(Executor, scipy/cupyx csr_matrix)` constructor now go
through it.

## Why this isn't *just* a refactor

The pre-existing sparse-matrix constructor took two structurally
different paths depending on input type:

* **CuPy CSR on a `CudaExecutor`** — zero-copy via
  `__cuda_array_interface__` (added in #98).
* **Anything else (NumPy / scipy / buffer protocol)** — a manual
  fallback that built `gko::array<...>::view(...)` on a
  `ReferenceExecutor` and handed those host arrays to
  `Csr::create(exec, ...)`, forcing a second host→device copy when
  the executor was CUDA.

After this PR, both paths flow through `gko_array_from_pyobject`,
which:

* honors the actual target `exec` for the buffer-protocol path
  (constructs the array directly on the requested executor instead
  of via a Reference detour),
* applies the dtype `typestr` validation that previously only the
  CUDA branch performed, to the host path as well, and
* gives `array` and `Csr` a single source of truth, so future fixes
  (e.g. the cross-platform integer-dtype-char fix in the
  follow-up MPI PR) automatically apply to both.

Behavior change for sparse matrices on CUDA built from
NumPy/scipy input: now allocated and copied directly on the target
device executor instead of through a host `ReferenceExecutor`
intermediate.

## Diff

```
 src/cpp_bindings/array.cpp  | 70 +-----
 src/cpp_bindings/matrix.cpp | 84 +---------
 src/cpp_bindings/utils.hpp  | 66 +++++++
 3 files changed, 75 insertions(+), 147 deletions(-)
```

## Why this is its own PR

* Stands alone as a behavior-improving cleanup of #98's wake.
* Reviewers can sign off on it independent of the much larger MPI
  feature work that follows in the stacked PR-B.
* PR-B's Windows-portability fix is a one-line change against this
  helper — much easier to review when the helper itself has already
  been reviewed in isolation.

## Testing

The existing test suite covers all the input shapes: NumPy/scipy CSR
on `ReferenceExecutor`, CuPy CSR zero-copy on `CudaExecutor`, and
the dense-array constructors. No regressions observed locally.

## Stacked PR

Not stacked on anything (based on `main`). PR-B for the distributed
MPI bindings is stacked on top of this.
