### PR TITLE
Fix ILU binding API mismatch

### DIFF
--- a/src/cpp_bindings/preconditioner/ilu.cpp
+++ b/src/cpp_bindings/preconditioner/ilu.cpp
@@ -7,9 +7,7 @@
 
 template <typename ValueType, typename IndexType>
 using Ilu =
-    gko::preconditioner::Ilu<gko::solver::LowerTrs<ValueType, IndexType>,
-                             gko::solver::UpperTrs<ValueType, IndexType>,
-                             false>;
+    gko::preconditioner::Ilu<ValueType, false, IndexType>;
 
 template <typename ValueType, typename IndexType>
 void init_ilu(py::module_ &module_preconditioner, const std::string value_type,
@@ -36,7 +34,7 @@ void init_ilu(py::module_ &module_preconditioner, const std::string value_type,
             return gko::share(ilu_pre_factory->generate(par_ilu));
         }))
         .def("__repr__",
-             [=](const gko::solver::Gmres<ValueType> &o) { return repr_str; });
+             [=](const Ilu<ValueType, IndexType> &o) { return repr_str; });
 }
 
 void init_ilu_all_types(py::module_ &module_preconditioner)


### PR DESCRIPTION
# Description
<!--
 Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.  -->

Fixes the ILU preconditioner binding to match the updated Ginkgo API.

The previous binding used the old `gko::preconditioner::Ilu` template interface with explicit lower and upper triangular solver types. The current Ginkgo API expects the template parameters in the form:

```cpp
gko::preconditioner::Ilu<ValueType, ReverseApply, IndexType>
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
