### PR TITLE
Fix ILU binding API mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- Fix ILU preconditioner binding for the updated Ginkgo API [#107](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/107)
 - Add CuPy interoperability for zero-copy GPU data exchange via `__cuda_array_interface__`
 - Make it pip installable [#86](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/86)
 - Fix circular import issue by renaming `types.py` to `gko_types.py` [#85](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/85)

--- a/src/cpp_bindings/preconditioner/ilu.cpp
+++ b/src/cpp_bindings/preconditioner/ilu.cpp
@@ -6,8 +6,7 @@
 #include "../utils.hpp"
 
 template <typename ValueType, typename IndexType>
-using Ilu =
-    gko::preconditioner::Ilu<ValueType, false, IndexType>;
+using Ilu = gko::preconditioner::Ilu<ValueType, false, IndexType>;
 
 template <typename ValueType, typename IndexType>
 void init_ilu(py::module_ &module_preconditioner, const std::string value_type,

--- a/src/cpp_bindings/preconditioner/ilu.cpp
+++ b/src/cpp_bindings/preconditioner/ilu.cpp
@@ -6,7 +6,14 @@
 #include "../utils.hpp"
 
 template <typename ValueType, typename IndexType>
+#if GKO_VERSION_MAJOR == 1
+using Ilu =
+    gko::preconditioner::Ilu<gko::solver::LowerTrs<ValueType, IndexType>,
+                             gko::solver::UpperTrs<ValueType, IndexType>, false,
+                             IndexType>;
+#else
 using Ilu = gko::preconditioner::Ilu<ValueType, false, IndexType>;
+#endif
 
 template <typename ValueType, typename IndexType>
 void init_ilu(py::module_ &module_preconditioner, const std::string value_type,

--- a/src/cpp_bindings/preconditioner/ilu.cpp
+++ b/src/cpp_bindings/preconditioner/ilu.cpp
@@ -7,9 +7,7 @@
 
 template <typename ValueType, typename IndexType>
 using Ilu =
-    gko::preconditioner::Ilu<gko::solver::LowerTrs<ValueType, IndexType>,
-                             gko::solver::UpperTrs<ValueType, IndexType>,
-                             false>;
+    gko::preconditioner::Ilu<ValueType, false, IndexType>;
 
 template <typename ValueType, typename IndexType>
 void init_ilu(py::module_ &module_preconditioner, const std::string value_type,
@@ -36,7 +34,7 @@ void init_ilu(py::module_ &module_preconditioner, const std::string value_type,
             return gko::share(ilu_pre_factory->generate(par_ilu));
         }))
         .def("__repr__",
-             [=](const gko::solver::Gmres<ValueType> &o) { return repr_str; });
+             [=](const Ilu<ValueType, IndexType> &o) { return repr_str; });
 }
 
 void init_ilu_all_types(py::module_ &module_preconditioner)


### PR DESCRIPTION
# Description
<!--
 Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.  -->

Fixes the ILU preconditioner binding to match the updated Ginkgo API.

The previous binding used the old `gko::preconditioner::Ilu` template interface with explicit lower and upper triangular solver types. The current Ginkgo API expects the template parameters in the form:

```cpp
gko::preconditioner::Ilu<ValueType, ReverseApply, IndexType>
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing tests pass locally with my changes
