### PR TITLE
Add CG solver binding and tests

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,5 +4,7 @@ I hereby place all my contributions in this codebase under a MIT
 license, as specified in the repository's LICENSE file.
 
 Gregor Olenik <gregor.olenik@kit.edu>, Karlsruhe Institute of Technology\
-Keshvi Tuteja <keshvi.tuteja@kit.edu>, Karlsruhe Institute of Technology
-Rickard Holmberg <rickard.holmberg@novatronfusion.com>, Novatron Fusion Group
+Keshvi Tuteja <keshvi.tuteja@kit.edu>, Karlsruhe Institute of Technology\
+Rickard Holmberg <rickard.holmberg@novatronfusion.com>, Novatron Fusion Group\
+Yu-Hsiang Tsai <yhmtsai@gmail.com>, Technical University of Munich\
+Kai-Hui You <kai-hui.you@tum.de>, Technical University of Munich

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- Add CG solver binding and tests [#109](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/109)
 - Fix ILU preconditioner binding for the updated Ginkgo API [#107](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/107)
 - Add CuPy interoperability for zero-copy GPU data exchange via `__cuda_array_interface__`
 - Make it pip installable [#86](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/86)

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -13,6 +13,7 @@ set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/logger.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/executor.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/preconditioner/ilu.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/cg.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/config_solver.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/direct.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/gmres.cpp

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -13,6 +13,7 @@ void init_logger_all_types(py::module_ &);
 void init_gmres_all_types(py::module_ &);
 void init_direct_all_types(py::module_ &);
 void init_trs_all_types(py::module_ &);
+void init_cg_all_types(py::module_ &);
 void init_factorization(py::module_ &);
 void init_config_solver_all_types(py::module_ &);
 void init_ilu_all_types(py::module_ &);
@@ -78,6 +79,7 @@ PYBIND11_MODULE(pyGinkgoBindings, m)
     init_direct_all_types(module_solver);
     init_config_solver_all_types(module_solver);
     init_trs_all_types(module_solver);
+    init_cg_all_types(module_solver);
 
     py::module_ module_factorization = m.def_submodule(
         "factorization", "Submodule for Ginkgos factorization type bindings");

--- a/src/cpp_bindings/solver/cg.cpp
+++ b/src/cpp_bindings/solver/cg.cpp
@@ -39,7 +39,7 @@ void init_cg(py::module_ &module_solver, const std::string value_type)
                                  .with_baseline(stop_mode)
                                  .with_reduction_factor(reduction_factor))
                          .on(exec));
-                 return gko::share(fact->generate(system_matrix));
+                 return gko::share(factory->generate(system_matrix));
              }),
              py::arg("exec"), py::arg("system_matrix"), py::arg("max_iters"),
              py::arg("reduction_factor"), py::arg("relative_stop_mode"))
@@ -51,7 +51,7 @@ void init_cg(py::module_ &module_solver, const std::string value_type)
                  auto stop_mode = (relative_stop_mode)
                                       ? gko::stop::mode::rhs_norm
                                       : gko::stop::mode::absolute;
-                 auto fact = gko::share(
+                 auto factory = gko::share(
                      gko::solver::Cg<ValueType>::build()
                          .with_criteria(
                              gko::stop::Iteration::build().with_max_iters(
@@ -61,7 +61,7 @@ void init_cg(py::module_ &module_solver, const std::string value_type)
                                  .with_reduction_factor(reduction_factor))
                          .with_generated_preconditioner(preconditioner)
                          .on(exec));
-                 return gko::share(fact->generate(system_matrix));
+                 return gko::share(factory->generate(system_matrix));
              }),
              py::arg("exec"), py::arg("system_matrix"),
              py::arg("preconditioner"), py::arg("max_iters"),

--- a/src/cpp_bindings/solver/cg.cpp
+++ b/src/cpp_bindings/solver/cg.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+//
+// SPDX-License-Identifier: MIT
+
+#include <tuple>
+
+#include "../python.hpp"
+#include "../utils.hpp"
+
+template <typename ValueType>
+void init_cg(py::module_ &module_solver, const std::string value_type)
+{
+    std::string pyclass_name = "cg_" + value_type;
+    std::string repr_str = "pygko.solver." + pyclass_name + " object";
+
+    auto initialize_logger = [](gko::solver::Cg<ValueType> &o) {
+        std::shared_ptr<gko::log::Convergence<ValueType>> convergence_logger =
+            gko::log::Convergence<ValueType>::create();
+        o.add_logger(convergence_logger);
+        return convergence_logger;
+    };
+
+    py::class_<gko::solver::Cg<ValueType>,
+               std::shared_ptr<gko::solver::Cg<ValueType>>, gko::LinOp>(
+        module_solver, pyclass_name.c_str())
+        .def(py::init([](std::shared_ptr<gko::Executor> exec,
+                         std::shared_ptr<const gko::LinOp> system_matrix,
+                         size_t max_iters, ValueType reduction_factor,
+                         bool relative_stop_mode) {
+                 auto stop_mode = (relative_stop_mode)
+                                      ? gko::stop::mode::rhs_norm
+                                      : gko::stop::mode::absolute;
+                 auto fact = gko::share(
+                     gko::solver::Cg<ValueType>::build()
+                         .with_criteria(
+                             gko::stop::Iteration::build().with_max_iters(
+                                 max_iters),
+                             gko::stop::ResidualNorm<ValueType>::build()
+                                 .with_baseline(stop_mode)
+                                 .with_reduction_factor(reduction_factor))
+                         .on(exec));
+                 return gko::share(fact->generate(system_matrix));
+             }),
+             py::arg("exec"), py::arg("system_matrix"), py::arg("max_iters"),
+             py::arg("reduction_factor"), py::arg("relative_stop_mode"))
+        .def(py::init([](std::shared_ptr<gko::Executor> exec,
+                         std::shared_ptr<const gko::LinOp> system_matrix,
+                         std::shared_ptr<const gko::LinOp> preconditioner,
+                         size_t max_iters, ValueType reduction_factor,
+                         bool relative_stop_mode) {
+                 auto stop_mode = (relative_stop_mode)
+                                      ? gko::stop::mode::rhs_norm
+                                      : gko::stop::mode::absolute;
+                 auto fact = gko::share(
+                     gko::solver::Cg<ValueType>::build()
+                         .with_criteria(
+                             gko::stop::Iteration::build().with_max_iters(
+                                 max_iters),
+                             gko::stop::ResidualNorm<ValueType>::build()
+                                 .with_baseline(stop_mode)
+                                 .with_reduction_factor(reduction_factor))
+                         .with_generated_preconditioner(preconditioner)
+                         .on(exec));
+                 return gko::share(fact->generate(system_matrix));
+             }),
+             py::arg("exec"), py::arg("system_matrix"),
+             py::arg("preconditioner"), py::arg("max_iters"),
+             py::arg("reduction_factor"), py::arg("relative_stop_mode"))
+        // TODO: not sure, whether we actually still need this function
+        .def("initialize_logger", initialize_logger)
+        .def("__repr__",
+             [=](const gko::solver::Cg<ValueType> &o) { return repr_str; })
+        .def(
+            "apply",
+            [=](gko::solver::Cg<ValueType> &d,
+                std::shared_ptr<const gko::LinOp> b,
+                std::shared_ptr<gko::LinOp> x) {
+                auto logger = initialize_logger(d);
+                d.apply(b, x);
+                return std::make_tuple(logger, x);
+            },
+            py::arg("b"), py::arg("x"),
+            "Applies the solver on b (rhs) and x (initial guess).\n"
+            "Changes the initial guess inplace.\n"
+            "Returns a tuple: (logger object, result)");
+}
+
+void init_cg_all_types(py::module_ &module_solver)
+{
+#define DECLARE_CG_SOLVER(ValueType) \
+    init_cg<ValueType>(module_solver, #ValueType);
+    PYGKO_INSTANTIATE_FOR_EACH_NON_COMPLEX_VALUE_TYPE(DECLARE_CG_SOLVER);
+}

--- a/src/cpp_bindings/solver/cg.cpp
+++ b/src/cpp_bindings/solver/cg.cpp
@@ -30,7 +30,7 @@ void init_cg(py::module_ &module_solver, const std::string value_type)
                  auto stop_mode = (relative_stop_mode)
                                       ? gko::stop::mode::rhs_norm
                                       : gko::stop::mode::absolute;
-                 auto fact = gko::share(
+                 auto factory = gko::share(
                      gko::solver::Cg<ValueType>::build()
                          .with_criteria(
                              gko::stop::Iteration::build().with_max_iters(

--- a/tests/cpp_bindings/test_iterative_solver.py
+++ b/tests/cpp_bindings/test_iterative_solver.py
@@ -9,7 +9,7 @@ import pyGinkgo as pg
 import pyGinkgo.pyGinkgoBindings as pGB
 
 
-@pytest.mark.parametrize("solver_name", ["gmres"])
+@pytest.mark.parametrize("solver_name", ["gmres", "cg"])
 @pytest.mark.parametrize(
     "data_type",
     [
@@ -24,6 +24,11 @@ class TestIterativeSolverBinding:
     solver_args = {
         "gmres": {
             "krylov_dim": 10,
+            "max_iters": 1000,
+            "reduction_factor": 1e-06,
+            "relative_stop_mode": False,
+        },
+        "cg": {
             "max_iters": 1000,
             "reduction_factor": 1e-06,
             "relative_stop_mode": False,
@@ -61,6 +66,11 @@ class TestIterativeSolverBinding:
     def test_ilu_preconditioned_solver(
         self, solver_name, data_type: pg.gko_types.ValueType
     ):
+        if solver_name == "cg":
+            pytest.skip(
+                "ILU preconditioning is not suitable for CG because ILU is not guaranteed to be SPD"
+            )
+
         fn = os.path.dirname(os.path.realpath(__file__)) + "/fv1.mtx"
         reader_cls = getattr(pGB.matrix, f"read_Coo_{data_type}_int32")
         mtx = reader_cls(fn, self.ref)


### PR DESCRIPTION
# Description
<!--
 Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.  -->

Adds the Conjugate Gradient (CG) solver binding to pyGinkgo.

The implementation follows the existing iterative solver binding structure and exposes Ginkgo's CG solver through the Python bindings. It also adds tests for the CG binding to verify that the solver can be constructed and used from Python.

CG is intended for symmetric positive definite (SPD) systems, so the related solver test uses an SPD matrix case.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
