### PR TITLE
Fix issue#94 as_tensor handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Version 0.1.0 (unreleased)
+- Fix issue#94 Python helper API and tests [#111](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/111)
 - Add CG solver binding and tests [#109](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/109)
 - Internal test of PR#95: Add tests for sparse matrix transpose function [#110](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/110)
 - Fix ILU preconditioner binding for the updated Ginkgo API [#107](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/107)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Version 0.1.0 (unreleased)
-- Fix issue#94 Python helper API and tests [#111](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/111)
+- Fix issue #94 Python helper API and tests [#111](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/111)
 - Add CG solver binding and tests [#109](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/109)
 - Internal test of PR#95: Add tests for sparse matrix transpose function [#110](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/110)
 - Fix ILU preconditioner binding for the updated Ginkgo API [#107](https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/107)

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -59,6 +59,7 @@ def as_tensor(
             obj = obj.__array__()
 
     array_cls = getattr(pGB.matrix, "dense_" + dtype)
+    # Check explicitly for None because obj may contain a multi-element NumPy array.
     if obj is not None:
         return array_cls(executor, obj)
 

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -44,7 +44,8 @@ def as_tensor(
     fill: Optional[float] = None,
 ):
     """create a ginkgo array from a given object"""
-    if not dtype in gko_types.ValueType.values():
+    dtype = str(dtype)
+    if dtype not in gko_types.ValueType.values():
         raise ValueError(
             f"Not a valid dtype: {dtype}. " +
             "Possible choices are: " +
@@ -58,15 +59,17 @@ def as_tensor(
             obj = obj.__array__()
 
     array_cls = getattr(pGB.matrix, "dense_" + dtype)
-    if obj:
+    if obj is not None:
         return array_cls(executor, obj)
-    else:
-        res = array_cls(executor, dim)
+
+    if dim is None:
+        raise ValueError("Either obj or dim must be provided.")
+    
+    res = array_cls(executor, dim)
+    if fill is not None:
+        res.fill(fill)
         
-        if fill is not None:
-            res.fill(fill)
-        
-        return res
+    return res
 
 
 def read(
@@ -147,7 +150,7 @@ def eigen_solve(A,solver_args=None):
     hY = dense_cls(exec_obj, Q.__array__())
     return Lambda, hY
 
-def generate_solver(A, solver_args: dict = dict()):
+def generate_solver(A, solver_args=None):
     """Generate a solver based on the system matrix A
 
     Parameters: A - The system matrix
@@ -156,7 +159,7 @@ def generate_solver(A, solver_args: dict = dict()):
     Returns: the solver
     """
 
-    if not solver_args:
+    if solver_args is None or solver_args == {}:
         solver_args = {
             "type": "solver::Gmres",
             "preconditioner": {
@@ -179,7 +182,7 @@ def generate_solver(A, solver_args: dict = dict()):
     return solver
 
 def config_solve(A,b,x,solver_args=None):
-    if not solver_args:
+    if solver_args is None or solver_args == {}:
         solver_args = {
             "type": "solver::Gmres",
             "preconditioner": {
@@ -214,7 +217,7 @@ def triangular_solve(A,b,x,solver_args):
     trs.apply(b, x)
     return None, x
 
-def solve(A, b, initial_guess=None, solver_args: dict = dict(), kind="config"):
+def solve(A, b, initial_guess=None, solver_args: Optional[dict] = None, kind="config"):
     """Solve a given linear system, where A is the system matrix and b the RHS
 
     Parameters: A - The system matrix
@@ -229,7 +232,7 @@ def solve(A, b, initial_guess=None, solver_args: dict = dict(), kind="config"):
 
     ctor = globals()[kind+"_solve"]
 
-    if not initial_guess:
+    if initial_guess is None:
         dtype = type(A).__name__.split('_')[1]
         dense_cls = getattr(pGB.matrix, f"dense_{dtype}")
         dim = (A.shape[1], b.shape[1])

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -151,6 +151,25 @@ def eigen_solve(A,solver_args=None):
     hY = dense_cls(exec_obj, Q.__array__())
     return Lambda, hY
 
+def get_solver_default_config():
+    """Return the default solver configuration.
+
+    A new dictionary is returned on each call to avoid sharing mutable
+    default configuration between function calls.
+    """
+    return {
+        "type": "solver::Gmres",
+        "preconditioner": {
+            "type": "preconditioner::Ilu",
+            "reverse_apply": False,
+            "factorization": {"type": "factorization::ParIlu"},
+        },
+        "criteria": [
+            {"type": "Iteration", "max_iters": 1000},
+            {"type": "ResidualNorm", "reduction_factor": 1e-7},
+        ],
+    }
+
 def generate_solver(A, solver_args: Optional[dict] = None):
     """Generate a solver based on the system matrix A
 
@@ -162,22 +181,8 @@ def generate_solver(A, solver_args: Optional[dict] = None):
     """
 
     if solver_args is None or solver_args == {}:
-        solver_args = {
-            "type": "solver::Gmres",
-            "preconditioner": {
-                "type": "preconditioner::Ilu",
-                "reverse_apply": False,
-                "factorization": {"type": "factorization::ParIlu"},
-            },
-            "criteria": [
-                {"type": "Iteration", "max_iters": 1000},
-                {"type": "ResidualNorm", "reduction_factor": 1e-7},
-            ],
-        }
-    elif not isinstance(solver_args, dict):
-        raise TypeError(
-            "solver_args must be a dictionary or None"
-        )
+        solver_args = get_solver_default_config()
+    
     solver_executor = A.get_executor()
      # TODO: Create a better way to check the dtype of the matrix
     dtype = type(A).__name__.split('_')[1]
@@ -187,20 +192,9 @@ def generate_solver(A, solver_args: Optional[dict] = None):
     )
     return solver
 
-def config_solve(A,b,x,solver_args=None):
+def config_solve(A, b, x, solver_args: Optional[dict] = None):
     if solver_args is None or solver_args == {}:
-        solver_args = {
-            "type": "solver::Gmres",
-            "preconditioner": {
-                "type": "preconditioner::Ilu",
-                "reverse_apply": False,
-                "factorization": {"type": "factorization::ParIlu"},
-            },
-            "criteria": [
-                {"type": "Iteration", "max_iters": 1000},
-                {"type": "ResidualNorm", "reduction_factor": 1e-7},
-            ],
-        }
+        solver_args = get_solver_default_config()
 
     solver_executor = A.get_executor()
     dtype = type(A).__name__.split('_')[1]
@@ -229,12 +223,14 @@ def solve(A, b, initial_guess=None, solver_args: Optional[dict] = None, kind="co
     Parameters: A - The system matrix
                 b - The right hand side vector
                 initial_guess - The initial guess
-                solver - The solver
-                solver_args - A dictionary that is forwarded to the solver containing
-                    arguments, eg {'type': 'solver::Cg', 'criteria': [{"type": "Iteration", "max_iters": 100}]}
+                solver_args - An optional dictionary forwarded to the solver, 
+                eg {'type': 'solver::Cg', 'criteria': [{"type": "Iteration", "max_iters": 100}]}
                 kind - the underlying solver, eg. config
     Returns: tuple of a logger object and solution vector
     """
+
+    if solver_args is None or solver_args == {}:
+        solver_args = get_solver_default_config()
 
     ctor = globals()[kind+"_solve"]
 

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -4,6 +4,7 @@
 
 import os
 import json
+import copy
 import numpy as np
 from typing import Optional, Union
 
@@ -170,7 +171,7 @@ def get_solver_default_config():
         ],
     }
 
-def generate_solver(A, solver_args: Optional[dict] = None):
+def generate_solver(A, solver_args: dict = get_solver_default_config()):
     """Generate a solver based on the system matrix A
 
     Parameters: A - The system matrix
@@ -180,8 +181,13 @@ def generate_solver(A, solver_args: Optional[dict] = None):
     Returns: the solver
     """
 
-    if solver_args is None or solver_args == {}:
+    if not isinstance(solver_args, dict):
+        raise TypeError("solver_args must be a dictionary.")
+
+    if solver_args == {}:
         solver_args = get_solver_default_config()
+    else:
+        solver_args = copy.deepcopy(solver_args)
     
     solver_executor = A.get_executor()
      # TODO: Create a better way to check the dtype of the matrix
@@ -192,9 +198,14 @@ def generate_solver(A, solver_args: Optional[dict] = None):
     )
     return solver
 
-def config_solve(A, b, x, solver_args: Optional[dict] = None):
-    if solver_args is None or solver_args == {}:
+def config_solve(A, b, x, solver_args: dict = get_solver_default_config()):
+    if not isinstance(solver_args, dict):
+        raise TypeError("solver_args must be a dictionary.")
+
+    if solver_args == {}:
         solver_args = get_solver_default_config()
+    else:
+        solver_args = copy.deepcopy(solver_args)
 
     solver_executor = A.get_executor()
     dtype = type(A).__name__.split('_')[1]
@@ -217,7 +228,7 @@ def triangular_solve(A,b,x,solver_args):
     trs.apply(b, x)
     return None, x
 
-def solve(A, b, initial_guess=None, solver_args: Optional[dict] = None, kind="config"):
+def solve(A, b, initial_guess=None, solver_args: dict = get_solver_default_config(), kind="config"):
     """Solve a given linear system, where A is the system matrix and b the RHS
 
     Parameters: A - The system matrix
@@ -229,8 +240,13 @@ def solve(A, b, initial_guess=None, solver_args: Optional[dict] = None, kind="co
     Returns: tuple of a logger object and solution vector
     """
 
-    if solver_args is None or solver_args == {}:
+    if not isinstance(solver_args, dict):
+        raise TypeError("solver_args must be a dictionary.")
+
+    if solver_args == {}:
         solver_args = get_solver_default_config()
+    else:
+        solver_args = copy.deepcopy(solver_args)
 
     ctor = globals()[kind+"_solve"]
 

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -150,12 +150,13 @@ def eigen_solve(A,solver_args=None):
     hY = dense_cls(exec_obj, Q.__array__())
     return Lambda, hY
 
-def generate_solver(A, solver_args=None):
+def generate_solver(A, solver_args: Optional[dict] = None):
     """Generate a solver based on the system matrix A
 
     Parameters: A - The system matrix
-                solver_args - A dictionary that is forwarded to the solver containing
-                    arguments, eg {'type': 'solver::Cg', 'criteria': {'max_iters': 100}}
+                solver_args - An optional dictionary containing 
+                    arguments forwarded to the solver, 
+                    for example: {"type": "solver::Cg", "criteria": {"max_iters": 100}}.
     Returns: the solver
     """
 
@@ -172,6 +173,10 @@ def generate_solver(A, solver_args=None):
                 {"type": "ResidualNorm", "reduction_factor": 1e-7},
             ],
         }
+    elif not isinstance(solver_args, dict):
+        raise TypeError(
+            "solver_args must be a dictionary or None"
+        )
     solver_executor = A.get_executor()
      # TODO: Create a better way to check the dtype of the matrix
     dtype = type(A).__name__.split('_')[1]

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -157,7 +157,7 @@ def generate_solver(A, solver_args: Optional[dict] = None):
     Parameters: A - The system matrix
                 solver_args - An optional dictionary containing 
                     arguments forwarded to the solver, 
-                    for example: {"type": "solver::Cg", "criteria": {"max_iters": 100}}.
+                    for example: {"type": "solver::Cg", "criteria": [{"type": "Iteration", "max_iters": 100}]}.
     Returns: the solver
     """
 
@@ -231,7 +231,7 @@ def solve(A, b, initial_guess=None, solver_args: Optional[dict] = None, kind="co
                 initial_guess - The initial guess
                 solver - The solver
                 solver_args - A dictionary that is forwarded to the solver containing
-                    arguments, eg {'type': 'solver::Cg', 'criteria': {'max_iters': 100}}
+                    arguments, eg {'type': 'solver::Cg', 'criteria': [{"type": "Iteration", "max_iters": 100}]}
                 kind - the underlying solver, eg. config
     Returns: tuple of a logger object and solution vector
     """

--- a/tests/pyGinkgo/CMakeLists.txt
+++ b/tests/pyGinkgo/CMakeLists.txt
@@ -19,3 +19,4 @@ endfunction()
 
 pyginkgo_python_test(solve)
 pyginkgo_python_test(RR)
+pyginkgo_python_test(core)

--- a/tests/pyGinkgo/test_core.py
+++ b/tests/pyGinkgo/test_core.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-from pathlib import Path
-
 import os
 import numpy as np
 import pytest

--- a/tests/pyGinkgo/test_core.py
+++ b/tests/pyGinkgo/test_core.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+#
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+import os
+import numpy as np
+import pytest
+
+import pyGinkgo as pg
+import pyGinkgo.pyGinkgoBindings as pGB
+
+
+d_type_map = {
+    "half": np.float16,
+    "float": np.float32,
+    "double": np.float64,
+}
+
+
+class TestCore:
+    @pytest.fixture(autouse=True, params=list(d_type_map.keys()))
+    def __post_init__(self, request):
+        self.data_type = request.param
+        self.executor = pGB.ReferenceExecutor()
+        self.fn = os.path.dirname(os.path.realpath(__file__)) + "/fv1.mtx"
+
+        self.reader_cls = getattr(pGB.matrix, f"read_Coo_{self.data_type}_int32")
+        self.dense_cls = getattr(pGB.matrix, f"dense_{self.data_type}")
+
+        self.mtx = self.reader_cls(self.fn, self.executor)
+        self.rows = self.mtx.shape[0]
+        self.cols = self.mtx.shape[1]
+
+    def test_as_tensor_accepts_numpy_array(self):
+        data = np.array([[1.0], [2.0], [3.0]], dtype=d_type_map[self.data_type])
+
+        tensor = pg.as_tensor(
+            obj=data,
+            device=self.executor,
+            dtype=self.data_type,
+        )
+
+        assert tensor.shape == data.shape
+
+        np_tensor = np.array(tensor.copy_to_host()).reshape(tensor.shape)
+        assert np.allclose(np_tensor, data)
+
+    def test_as_tensor_can_create_filled_tensor_from_dim(self):
+        tensor = pg.as_tensor(
+            dim=(self.rows, 1),
+            device=self.executor,
+            dtype=self.data_type,
+            fill=1.0,
+        )
+
+        assert tensor.shape == (self.rows, 1)
+
+        np_tensor = np.array(tensor.copy_to_host()).reshape(tensor.shape)
+        assert np.allclose(np_tensor, np.ones((self.rows, 1)))
+
+    def test_as_tensor_requires_obj_or_dim(self):
+        with pytest.raises(ValueError, match="Either obj or dim must be provided"):
+            pg.as_tensor(
+                device=self.executor,
+                dtype=self.data_type,
+            )
+
+    def test_as_tensor_rejects_invalid_dtype(self):
+        with pytest.raises(ValueError, match="Not a valid dtype"):
+            pg.as_tensor(
+                dim=(self.rows, 1),
+                device=self.executor,
+                dtype="invalid_dtype",
+            )
+
+    def test_read_can_read_sparse_matrix(self):
+        matrix = pg.read(
+            self.fn,
+            format="Coo",
+            dtype=self.data_type,
+            itype="int32",
+            device=self.executor,
+        )
+
+        assert matrix.shape == self.mtx.shape
+        assert matrix.get_num_stored_elements() == self.mtx.get_num_stored_elements()
+
+    def test_read_rejects_invalid_format(self):
+        with pytest.raises(ValueError, match="Not a valid matrix format"):
+            pg.read(
+                self.fn,
+                format="invalid_format",
+                dtype=self.data_type,
+                itype="int32",
+                device=self.executor,
+            )
+
+    def test_read_rejects_invalid_dtype(self):
+        with pytest.raises(ValueError, match="Not a valid dtype"):
+            pg.read(
+                self.fn,
+                format="Coo",
+                dtype="invalid_dtype",
+                itype="int32",
+                device=self.executor,
+            )
+
+    def test_read_rejects_invalid_itype_for_sparse_matrix(self):
+        with pytest.raises(ValueError, match="Not a valid itype"):
+            pg.read(
+                self.fn,
+                format="Coo",
+                dtype=self.data_type,
+                itype="invalid_itype",
+                device=self.executor,
+            )
+
+    def test_generate_solver_can_apply_solver(self):
+        solver_args = {
+            "type": "solver::Cg",
+            "criteria": [
+                {"type": "Iteration", "max_iters": 2},
+            ],
+        }
+
+        rhs = self.dense_cls(self.executor, (self.rows, 1))
+        rhs.fill(1.0)
+
+        result = self.dense_cls(self.executor, (self.rows, 1))
+        result.fill(0.0)
+
+        solver = pg.generate_solver(self.mtx, solver_args=solver_args)
+        solver.apply(rhs, result)
+
+        assert result.shape == (self.rows, 1)
+
+        np_result = np.array(result.copy_to_host()).reshape(result.shape)
+        assert len(np.nonzero(np_result)[0]) > 0
+
+    def test_config_solve_returns_logger_and_result(self):
+        solver_args = {
+            "type": "solver::Cg",
+            "criteria": [
+                {"type": "Iteration", "max_iters": 2},
+            ],
+        }
+
+        rhs = self.dense_cls(self.executor, (self.rows, 1))
+        rhs.fill(1.0)
+
+        initial_guess = self.dense_cls(self.executor, (self.rows, 1))
+        initial_guess.fill(0.0)
+
+        logger, result = pg.config_solve(
+            self.mtx,
+            rhs,
+            initial_guess,
+            solver_args=solver_args,
+        )
+
+        assert logger.get_num_iterations() == 2
+        assert result.shape == (self.rows, 1)
+
+    def test_solve_can_create_default_initial_guess(self):
+        solver_args = {
+            "type": "solver::Cg",
+            "criteria": [
+                {"type": "Iteration", "max_iters": 2},
+            ],
+        }
+
+        rhs = self.dense_cls(self.executor, (self.rows, 1))
+        rhs.fill(1.0)
+
+        logger, result = pg.solve(
+            self.mtx,
+            rhs,
+            solver_args=solver_args,
+        )
+
+        assert logger.get_num_iterations() == 2
+        assert result.shape == (self.rows, 1)
+
+        np_result = np.array(result.copy_to_host())
+        assert len(np.nonzero(np_result)[0]) > 0


### PR DESCRIPTION
# Description
<!--
 Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.  -->

Fixes #94

This PR fixes the high-level Python helper API by updating `as_tensor` to check NumPy array inputs with `obj is not None` instead of `if obj`. This avoids the ambiguous truth-value error raised by multi-element NumPy arrays.

It also adds Python-level tests for helper functions in `core.py`, including:

- `as_tensor`
- `read`
- `generate_solver`
- `config_solve`
- `solve`

The new tests verify dtype dispatch, NumPy input handling, matrix reading, solver generation, and default initial-guess creation.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
