### PR TITLE
Add distributed bindings (MPI multi-GPU support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,5 @@ cython_debug/
 src/pyGinkgo/pyGinkgoBindings/
 
 .venv_p
+.py-build-cmake_cache/
+py-build-cmake.local.toml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 cmake_minimum_required(VERSION 3.20)
 project(pyGinkgo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,33 @@ target_link_libraries(pyGinkgoBindings PRIVATE Ginkgo::ginkgo)
 target_link_libraries(pyGinkgoBindings PUBLIC nlohmann_json::nlohmann_json)
 set_property(TARGET pyGinkgoBindings PROPERTY CXX_STANDARD 14)
 
+# MPI / distributed bindings: only built when Ginkgo is compiled with MPI.
+# FetchContent builds expose GINKGO_BUILD_MPI as a cache variable, while installed
+# Ginkgo packages may only expose it through target compile definitions.
+set(PYGINKGO_GINKGO_HAS_MPI OFF)
+if(DEFINED GINKGO_BUILD_MPI AND GINKGO_BUILD_MPI)
+  set(PYGINKGO_GINKGO_HAS_MPI ON)
+endif()
+if(TARGET Ginkgo::ginkgo)
+  get_target_property(_ginkgo_compile_defs Ginkgo::ginkgo INTERFACE_COMPILE_DEFINITIONS)
+  if(_ginkgo_compile_defs)
+    foreach(_ginkgo_def IN LISTS _ginkgo_compile_defs)
+      if(_ginkgo_def MATCHES "(^|[<:])GINKGO_BUILD_MPI($|[>:])")
+        set(PYGINKGO_GINKGO_HAS_MPI ON)
+      endif()
+    endforeach()
+  endif()
+endif()
+
+if(PYGINKGO_GINKGO_HAS_MPI)
+  find_package(MPI REQUIRED COMPONENTS CXX)
+  target_compile_definitions(pyGinkgoBindings PRIVATE GINKGO_BUILD_MPI)
+  target_link_libraries(pyGinkgoBindings PRIVATE MPI::MPI_CXX)
+  message(STATUS "pyGinkgo: MPI-distributed bindings enabled")
+else()
+  message(STATUS "pyGinkgo: MPI-distributed bindings disabled")
+endif()
+
 # Disable false positive warnings from GCC (>= 12.4 and <
 # 13)(https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824 and
 # https://github.com/pybind/pybind11/issues/5224)
@@ -158,7 +185,8 @@ set(PYGINKGO_PYTHON_FILES
     ${PROJECT_SOURCE_DIR}/src/pyGinkgo/device.py
     ${PROJECT_SOURCE_DIR}/src/pyGinkgo/solver.py
     ${PROJECT_SOURCE_DIR}/src/pyGinkgo/rayleigh_ritz.py
-    ${PROJECT_SOURCE_DIR}/src/pyGinkgo/preconditioner.py)
+    ${PROJECT_SOURCE_DIR}/src/pyGinkgo/preconditioner.py
+    ${PROJECT_SOURCE_DIR}/src/pyGinkgo/distributed.py)
 # TODO: it seems reasonable to be to start using glob recuse above
 
 add_custom_target(

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -36,7 +36,7 @@ if not pg.distributed.available:
 
 # ---------------------------------------------------------------- parameters
 N = 16                       # global system size
-executor = pg.device("cpu")  # "cpu", "omp", or "cuda" / "cuda:0"
+executor = pg.device("cuda")  # "cpu", "omp", or "cuda" / "cuda:0"
 value = "double"             # matches np.float64
 
 # ----------------------------------------------------- row distribution (1D)

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 Imad Kissami
+#
+# SPDX-License-Identifier: MIT
+
+"""Minimal distributed pyGinkgo example.
+
+Solves the 1D Poisson problem ``A x = b`` where ``A`` is the N x N tridiagonal
+Laplacian (diag = 2, off-diag = -1) and ``b = 1``, using Ginkgo's MPI-distributed
+matrix/vector and a CG solver.
+
+Each MPI rank owns a contiguous block of rows and assembles ONLY its own rows
+(like PETSc): Ginkgo handles the off-process communication during the solve.
+
+Run with:
+    mpirun -n 4 python examples/distributed_solver.py
+
+Requires pyGinkgo built with MPI support (GINKGO_BUILD_MPI=ON).
+"""
+
+import json
+
+import numpy as np
+from mpi4py import MPI
+
+import pyGinkgo as pg
+from pyGinkgo import pyGinkgoBindings as pGB
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+if not pg.distributed.available:
+    raise RuntimeError(
+        "pyGinkgo was built without MPI support (GINKGO_BUILD_MPI=ON). "
+        "The distributed bindings are unavailable.")
+
+# ---------------------------------------------------------------- parameters
+N = 16                       # global system size
+executor = pg.device("cpu")  # "cpu", "omp", or "cuda" / "cuda:0"
+value = "double"             # matches np.float64
+
+# ----------------------------------------------------- row distribution (1D)
+# owners[g] = rank that owns global row g. Split the N rows into contiguous
+# blocks, one per rank.
+counts = [N // size + (1 if r < N % size else 0) for r in range(size)]
+offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.int32)
+start, end = offsets[rank], offsets[rank + 1]
+owned_rows = np.arange(start, end, dtype=np.int32)
+
+owners = np.empty(N, dtype=np.int32)
+for r in range(size):
+    owners[offsets[r]:offsets[r + 1]] = r
+
+partition = pg.distributed.build_partition(executor, owners, size)
+
+# --------------------------------------------- local assembly (owned rows only)
+# 1D Laplacian stencil: row i has 2 on the diagonal and -1 to its neighbours.
+# Indices are 0-based GLOBAL indices.
+rows, cols, vals = [], [], []
+for i in range(start, end):
+    rows.append(i); cols.append(i); vals.append(2.0)
+    if i > 0:
+        rows.append(i); cols.append(i - 1); vals.append(-1.0)
+    if i < N - 1:
+        rows.append(i); cols.append(i + 1); vals.append(-1.0)
+
+rows = np.asarray(rows, dtype=np.int32)
+cols = np.asarray(cols, dtype=np.int32)
+vals = np.asarray(vals, dtype=np.float64)
+
+A = pg.distributed.matrix(executor, comm, partition, rows, cols, vals, N,
+                          dtype=value)
+
+# ------------------------------------------------------ distributed RHS / sol
+b_local = np.ones(owned_rows.size, dtype=np.float64)        # b = 1
+x_local = np.zeros(owned_rows.size, dtype=np.float64)       # initial guess 0
+
+b = pg.distributed.vector(executor, comm, partition, owned_rows, b_local, N,
+                          dtype=value)
+x = pg.distributed.vector(executor, comm, partition, owned_rows, x_local, N,
+                          dtype=value)
+
+# ------------------------------------------------------------------- solve
+solver_args = json.dumps({
+    "type": "solver::Cg",
+    "criteria": [
+        {"type": "Iteration", "max_iters": 1000},
+        {"type": "ResidualNorm", "reduction_factor": 1e-10},
+    ],
+})
+
+logger = pGB.solver.config_solve_double(executor, A, b, x, solver_args)
+
+# ----------------------------------------------------------------- results
+# Each rank reads its own slice of the solution (processor-local part).
+sol_local = pg.distributed.vector_local(x, dtype=value)
+
+if rank == 0:
+    print(f"[pyGinkgo distributed] N={N} ranks={size} "
+          f"converged={logger.has_converged()} "
+          f"iters={logger.get_num_iterations()}")
+
+# Gather the full solution on rank 0 just to print it (only for this demo).
+full = comm.gather(np.asarray(sol_local).ravel(), root=0)
+if rank == 0:
+    x_full = np.concatenate(full)
+    print("solution:", np.array2string(x_full, precision=4, suppress_small=True))

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -19,4 +19,5 @@ set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/gmres.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/triangular.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/factorization/factorization.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp_bindings/distributed.cpp
     PARENT_SCOPE)

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/python.cpp

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -1,0 +1,414 @@
+// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "python.hpp"
+#include "utils.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace py = pybind11;
+
+#if GINKGO_BUILD_MPI
+
+#include <mpi.h>
+
+#include <ginkgo/core/base/device_matrix_data.hpp>
+#include <ginkgo/core/base/mpi.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/partition.hpp>
+#include <ginkgo/core/distributed/vector.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+namespace dist = gko::experimental::distributed;
+namespace mpi = gko::experimental::mpi;
+
+using LIT = gko::int32;  // local index type
+using GIT = gko::int32;  // global index type (int32: matches manapy ls_compute
+                         // triplets; caps global DOFs at ~2.1e9, fine here)
+using PartT = dist::Partition<LIT, GIT>;
+
+static mpi::communicator comm_from_fortran(long fortran_handle)
+{
+    MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(fortran_handle));
+    return mpi::communicator(c);
+}
+
+static py::buffer_info checked_1d(py::array array, const char* name)
+{
+    auto info = array.request();
+    if (info.ndim != 1) {
+        std::ostringstream os;
+        os << name << " must be a 1-D array, got " << info.ndim << " dimensions";
+        throw py::value_error(os.str());
+    }
+    return info;
+}
+
+static void check_same_length(py::ssize_t lhs, const char* lhs_name,
+                              py::ssize_t rhs, const char* rhs_name)
+{
+    if (lhs != rhs) {
+        std::ostringstream os;
+        os << lhs_name << " and " << rhs_name << " must have matching lengths ("
+           << lhs << " != " << rhs << ")";
+        throw py::value_error(os.str());
+    }
+}
+
+template <typename T>
+static gko::array<T> host_array_from_numpy(
+    std::shared_ptr<const gko::Executor> host, py::array_t<T> array,
+    const char* name)
+{
+    auto info = checked_1d(array, name);
+    auto n = static_cast<gko::size_type>(info.shape[0]);
+    gko::array<T> out(host, n);
+    std::copy_n(static_cast<const T*>(info.ptr), n, out.get_data());
+    return out;
+}
+
+template <typename IndexType>
+static void validate_global_indices(py::array_t<IndexType> array, const char* name,
+                                    gko::size_type global_size)
+{
+    auto info = checked_1d(array, name);
+    const auto* data = static_cast<const IndexType*>(info.ptr);
+    for (py::ssize_t i = 0; i < info.shape[0]; ++i) {
+        const auto idx = data[i];
+        if (idx < 0 || static_cast<gko::size_type>(idx) >= global_size) {
+            std::ostringstream os;
+            os << name << " contains out-of-range global index " << idx
+               << " at position " << i << " for global size " << global_size;
+            throw py::value_error(os.str());
+        }
+    }
+}
+
+static void validate_partition_size(const PartT& partition,
+                                    gko::size_type global_size)
+{
+    if (static_cast<gko::size_type>(partition.get_size()) != global_size) {
+        std::ostringstream os;
+        os << "partition size (" << partition.get_size()
+           << ") must match global_size (" << global_size << ")";
+        throw py::value_error(os.str());
+    }
+}
+
+#ifdef GINKGO_BUILD_CUDA
+// Extract a device pointer + element count from a 1-D __cuda_array_interface__
+// object (CuPy, numba device array, ...).
+template <typename T>
+static std::pair<T*, gko::size_type> cai_ptr_and_size(py::object obj)
+{
+    auto cai = obj.attr("__cuda_array_interface__").cast<py::dict>();
+    auto data = cai["data"].cast<py::tuple>();
+    auto shape = cai["shape"].cast<py::tuple>();
+    if (shape.size() != 1) {
+        throw py::value_error(
+            "__cuda_array_interface__ array must be 1-D for the distributed "
+            "binding");
+    }
+    return {reinterpret_cast<T*>(data[0].cast<uintptr_t>()),
+            shape[0].cast<gko::size_type>()};
+}
+#endif
+
+// 1-D length of a numpy host array OR a __cuda_array_interface__ device array.
+static gko::size_type pyobj_len(py::object obj, const char* name)
+{
+#ifdef GINKGO_BUILD_CUDA
+    if (py::hasattr(obj, "__cuda_array_interface__")) {
+        auto cai = obj.attr("__cuda_array_interface__").cast<py::dict>();
+        auto shape = cai["shape"].cast<py::tuple>();
+        if (shape.size() != 1) {
+            throw py::value_error(std::string(name) + " must be a 1-D array");
+        }
+        return shape[0].cast<gko::size_type>();
+    }
+#endif
+    auto info = py::array(obj).request();
+    if (info.ndim != 1) {
+        throw py::value_error(std::string(name) + " must be a 1-D array");
+    }
+    return static_cast<gko::size_type>(info.shape[0]);
+}
+
+// Build an owning gko::array<T> on `exec` from either a numpy host array
+// (copied) or a __cuda_array_interface__ device array (zero-copy view, then an
+// owning device->device copy so the array can be moved into device_matrix_data
+// independently of the Python source's lifetime).
+template <typename T>
+static gko::array<T> array_on_exec(std::shared_ptr<const gko::Executor> exec,
+                                   py::object obj, const char* name)
+{
+#ifdef GINKGO_BUILD_CUDA
+    if (py::hasattr(obj, "__cuda_array_interface__")) {
+        auto pn = cai_ptr_and_size<T>(obj);
+        auto view = gko::array<T>::view(exec, pn.second, pn.first);
+        return gko::array<T>{exec, view};
+    }
+#endif
+    py::array_t<T, py::array::c_style | py::array::forcecast> arr(obj);
+    auto info = checked_1d(arr, name);
+    auto n = static_cast<gko::size_type>(info.shape[0]);
+    auto host = exec->get_master();
+    gko::array<T> host_arr(host, n);
+    std::copy_n(static_cast<const T*>(info.ptr), n, host_arr.get_data());
+    return gko::array<T>{exec, host_arr};
+}
+
+static std::shared_ptr<PartT> build_partition(
+    std::shared_ptr<gko::Executor> exec,
+    py::array_t<int, py::array::c_style | py::array::forcecast> owners,
+    int num_parts)
+{
+    if (num_parts <= 0) {
+        throw py::value_error("num_parts must be positive");
+    }
+
+    auto owner_info = checked_1d(owners, "owners");
+    if (owner_info.shape[0] == 0) {
+        throw py::value_error("owners must not be empty");
+    }
+    const auto* owner_data = static_cast<const int*>(owner_info.ptr);
+    for (py::ssize_t i = 0; i < owner_info.shape[0]; ++i) {
+        if (owner_data[i] < 0 || owner_data[i] >= num_parts) {
+            std::ostringstream os;
+            os << "owners contains invalid part id " << owner_data[i]
+               << " at position " << i << " for num_parts=" << num_parts;
+            throw py::value_error(os.str());
+        }
+    }
+
+    auto host = gko::ReferenceExecutor::create();
+    auto mapping_host = host_array_from_numpy<int>(host, owners, "owners");
+    auto mapping = gko::array<int>(exec, mapping_host);
+    return gko::share(PartT::build_from_mapping(exec, mapping, num_parts));
+}
+
+template <typename ValueType>
+static std::shared_ptr<gko::LinOp> build_matrix(
+    std::shared_ptr<gko::Executor> exec, long comm_handle,
+    std::shared_ptr<PartT> partition, py::object rows, py::object cols,
+    py::object vals, gko::size_type global_size)
+{
+    auto n = pyobj_len(rows, "rows");
+    check_same_length(static_cast<py::ssize_t>(n), "rows",
+                      static_cast<py::ssize_t>(pyobj_len(cols, "cols")), "cols");
+    check_same_length(static_cast<py::ssize_t>(n), "rows",
+                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")), "vals");
+    validate_partition_size(*partition, global_size);
+
+    auto comm = comm_from_fortran(comm_handle);
+
+    // Assemble directly on the requested executor (device for CUDA). Inputs may
+    // be host numpy or device (__cuda_array_interface__) arrays; the latter are
+    // ingested zero-copy. The partition is already on `exec`, so assembly is
+    // executor-consistent (the host-staging workaround is no longer needed).
+    auto row_arr = array_on_exec<GIT>(exec, rows, "rows");
+    auto col_arr = array_on_exec<GIT>(exec, cols, "cols");
+    auto val_arr = array_on_exec<ValueType>(exec, vals, "vals");
+
+    gko::device_matrix_data<ValueType, GIT> data(
+        exec, gko::dim<2>{global_size, global_size}, std::move(row_arr),
+        std::move(col_arr), std::move(val_arr));
+
+    auto mat = dist::Matrix<ValueType, LIT, GIT>::create(exec, comm);
+    mat->read_distributed(data, partition, dist::assembly_mode::communicate);
+    return gko::share(std::move(mat));
+}
+
+template <typename ValueType>
+static std::shared_ptr<gko::LinOp> build_vector(
+    std::shared_ptr<gko::Executor> exec, long comm_handle,
+    std::shared_ptr<PartT> partition, py::object rows, py::object vals,
+    gko::size_type global_size)
+{
+    auto n = pyobj_len(rows, "rows");
+    check_same_length(static_cast<py::ssize_t>(n), "rows",
+                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")), "vals");
+    validate_partition_size(*partition, global_size);
+
+    auto comm = comm_from_fortran(comm_handle);
+
+    auto row_arr = array_on_exec<GIT>(exec, rows, "rows");
+    auto val_arr = array_on_exec<ValueType>(exec, vals, "vals");
+    auto nnz = row_arr.get_size();
+
+    gko::array<GIT> col_arr(exec, nnz);
+    col_arr.fill(GIT{0});
+
+    gko::device_matrix_data<ValueType, GIT> data(
+        exec, gko::dim<2>{global_size, 1}, std::move(row_arr),
+        std::move(col_arr), std::move(val_arr));
+
+    auto vec = dist::Vector<ValueType>::create(exec, comm);
+    vec->read_distributed(data, partition);
+    return gko::share(std::move(vec));
+}
+
+template <typename ValueType>
+static py::array_t<ValueType> vector_local(std::shared_ptr<gko::LinOp> v)
+{
+    auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
+    if (!vec) {
+        throw py::type_error(
+            "vector_local: object is not a distributed vector of the requested value type");
+    }
+    auto host = vec->get_executor()->get_master();
+    auto local = vec->get_local_vector();
+    auto host_local = gko::clone(host, local);
+    const auto nrows = static_cast<py::ssize_t>(host_local->get_size()[0]);
+    const auto ncols = static_cast<py::ssize_t>(host_local->get_size()[1]);
+    const auto stride = static_cast<py::ssize_t>(host_local->get_stride());
+    const auto* values = host_local->get_const_values();
+
+    if (ncols == 1) {
+        py::array_t<ValueType> out(nrows);
+        auto* out_data = static_cast<ValueType*>(out.request().ptr);
+        for (py::ssize_t row = 0; row < nrows; ++row) {
+            out_data[row] = values[row];
+        }
+        return out;
+    }
+
+    py::array_t<ValueType> out({nrows, ncols});
+    auto* out_data = static_cast<ValueType*>(out.request().ptr);
+    for (py::ssize_t col = 0; col < ncols; ++col) {
+        for (py::ssize_t row = 0; row < nrows; ++row) {
+            out_data[row * ncols + col] = values[row + col * stride];
+        }
+    }
+    return out;
+}
+
+// Overwrite a distributed vector's processor-local values IN PLACE (no
+// reallocation, no read_distributed). `vals` is a 1-D host numpy array or a
+// __cuda_array_interface__ device array whose length must equal the local size;
+// its entries are already in Ginkgo's processor-local ordering. Lets callers
+// reuse a single vector across solves instead of rebuilding it each time.
+template <typename ValueType>
+static void vector_set_local(std::shared_ptr<gko::LinOp> v, py::object vals)
+{
+    auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
+    if (!vec) {
+        throw py::type_error(
+            "vector_set_local: object is not a distributed vector of the "
+            "requested value type");
+    }
+    // The local part is owned by the vector; we only overwrite its values
+    // (no resize), so const_cast on the buffer is safe here.
+    auto* local = const_cast<gko::matrix::Dense<ValueType>*>(
+        vec->get_local_vector());
+    const auto nrows = local->get_size()[0];
+    const auto ncols = local->get_size()[1];
+    if (ncols != 1) {
+        throw py::value_error(
+            "vector_set_local supports column vectors only (ncols == 1)");
+    }
+    auto n = pyobj_len(vals, "vals");
+    if (n != nrows) {
+        std::ostringstream os;
+        os << "vals length (" << n << ") must match the vector's local size ("
+           << nrows << ")";
+        throw py::value_error(os.str());
+    }
+    auto exec = local->get_executor();
+    // Bring vals onto the vector's executor (host copy, or zero-copy device view
+    // then an owning copy), then overwrite the contiguous local buffer.
+    auto src = array_on_exec<ValueType>(exec, vals, "vals");
+    exec->copy(n, src.get_const_data(), local->get_values());
+}
+
+#ifdef GINKGO_BUILD_CUDA
+// Expose the device pointer + layout of a distributed vector's processor-local
+// part, so Python can wrap it zero-copy (CuPy / numba) without a device->host
+// copy. The buffer stays valid as long as the source vector is alive.
+template <typename ValueType>
+static py::tuple vector_local_device_info(std::shared_ptr<gko::LinOp> v)
+{
+    auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
+    if (!vec) {
+        throw py::type_error(
+            "vector_local_device: object is not a distributed vector of the "
+            "requested value type");
+    }
+    auto local = vec->get_local_vector();
+    return py::make_tuple(
+        reinterpret_cast<uintptr_t>(local->get_const_values()),
+        static_cast<py::ssize_t>(local->get_size()[0]),
+        static_cast<py::ssize_t>(local->get_size()[1]),
+        static_cast<py::ssize_t>(local->get_stride()));
+}
+#endif
+
+template <typename ValueType>
+static void init_distributed_for_type(py::module_& m, const std::string& vt)
+{
+    m.def(("matrix_" + vt).c_str(), &build_matrix<ValueType>, py::arg("exec"),
+          py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
+          py::arg("cols"), py::arg("vals"), py::arg("global_size"),
+          "Build a distributed Csr matrix from global COO triplets. The matrix "
+          "is square: its shape is global_size x global_size. Row/column indices "
+          "must lie in [0, global_size).");
+
+    m.def(("vector_" + vt).c_str(), &build_vector<ValueType>, py::arg("exec"),
+          py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
+          py::arg("vals"), py::arg("global_size"),
+          "Build a distributed vector from (global_row, value) entries. Global "
+          "rows not present in 'rows' default to zero.");
+
+    m.def(("vector_local_" + vt).c_str(), &vector_local<ValueType>,
+          py::arg("vector"),
+          "Return the processor-local part of a distributed vector as numpy.");
+
+    m.def(("vector_set_local_" + vt).c_str(), &vector_set_local<ValueType>,
+          py::arg("vector"), py::arg("vals"),
+          "Overwrite a distributed vector's processor-local values in place "
+          "(no reallocation). vals length must equal the local size.");
+
+#ifdef GINKGO_BUILD_CUDA
+    m.def(("vector_local_device_" + vt).c_str(),
+          &vector_local_device_info<ValueType>, py::arg("vector"),
+          "Return (device_ptr, nrows, ncols, stride) of a distributed vector's "
+          "processor-local part for zero-copy CuPy/numba wrapping.");
+#endif
+}
+
+void init_distributed(py::module_& m)
+{
+    py::class_<PartT, std::shared_ptr<PartT>>(m, "Partition")
+        .def("get_num_parts", &PartT::get_num_parts)
+        .def_property_readonly("size", [](const PartT& p) { return p.get_size(); })
+        .def("__repr__", [](const PartT& p) {
+            std::ostringstream os;
+            os << "<pyGinkgo.distributed.Partition size=" << p.get_size()
+               << " num_parts=" << p.get_num_parts() << ">";
+            return os.str();
+        });
+
+    m.def("build_partition", &build_partition, py::arg("exec"),
+          py::arg("owners"), py::arg("num_parts"),
+          "Build a distributed Partition from a global owner mapping "
+          "(owners[global_row] = rank).");
+
+    // half/bfloat16 distributed types are instantiated by Ginkgo only when it
+    // is built with GINKGO_ENABLE_HALF; PYGKO_ADAPT_HF compiles the half
+    // bindings out when half support is disabled (e.g. HALF=OFF on GCC 13).
+    PYGKO_ADAPT_HF(init_distributed_for_type<half>(m, "half"));
+    init_distributed_for_type<float>(m, "float");
+    init_distributed_for_type<double>(m, "double");
+
+    m.attr("available") = true;
+}
+
+#else  // GINKGO_BUILD_MPI
+
+void init_distributed(py::module_& m) { m.attr("available") = false; }
+
+#endif  // GINKGO_BUILD_MPI

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -21,6 +21,7 @@ void add_allocator_classes(py::module_ &);
 void add_stream_classes(py::module_ &);
 void add_dpcpp_queue_property_enum(py::module_ &);
 void add_executor_classes(py::module_ &);
+void init_distributed(py::module_ &);
 
 PYBIND11_MODULE(pyGinkgoBindings, m)
 {
@@ -88,4 +89,8 @@ PYBIND11_MODULE(pyGinkgoBindings, m)
     py::module_ module_preconditioner = m.def_submodule(
         "preconditioner", "Submodule for Ginkgos preconditioner type bindings");
     init_ilu_all_types(module_preconditioner);
+
+    py::module_ module_distributed = m.def_submodule(
+        "distributed", "Submodule for Ginkgos MPI-distributed type bindings");
+    init_distributed(module_distributed);
 }

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -25,9 +25,12 @@ std::shared_ptr<gko::LinOp> config_solver(std::shared_ptr<gko::Executor> exec,
     // This example does not use existing data.
     auto reg = gko::config::registry();
     // generate the linopfactory on the given executors
+    // Global index type int32 (matches the int32-global distributed binding;
+    // unused for non-distributed types, which only need ValueType + int32 local).
     auto solver_gen =
-        gko::config::parse(config, reg,
-                           gko::config::make_type_descriptor<ValueType>())
+        gko::config::parse(
+            config, reg,
+            gko::config::make_type_descriptor<ValueType, gko::int32, gko::int32>())
             .on(exec);
 
     // Create solver

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -12,3 +12,4 @@ from .rayleigh_ritz import *
 from . import gko_types
 from . import solver
 from . import preconditioner
+from . import distributed

--- a/src/pyGinkgo/distributed.py
+++ b/src/pyGinkgo/distributed.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+#
+# SPDX-License-Identifier: MIT
+
+from .pyGinkgoBindings import distributed as _distributed
+
+available = bool(_distributed.available)
+Partition = getattr(_distributed, "Partition", None)
+
+# Value types the API understands. Which ones are actually compiled depends on
+# the Ginkgo build (half requires GINKGO_ENABLE_HALF); _binding() checks at call
+# time and raises if a requested dtype is unavailable in this build.
+_VALID_DTYPES = ("half", "float", "double")
+
+
+def _require_available():
+    if not available:
+        raise RuntimeError(
+            "pyGinkgo distributed bindings are unavailable; build Ginkgo with MPI support."
+        )
+
+
+def _binding(prefix, dtype):
+    """Resolve a typed binding (e.g. ``matrix_double``), validating availability."""
+    _require_available()
+    if dtype not in _VALID_DTYPES:
+        raise ValueError(f"dtype must be one of {_VALID_DTYPES}, got {dtype!r}")
+    fn = getattr(_distributed, f"{prefix}_{dtype}", None)
+    if fn is None:
+        raise ValueError(
+            f"dtype {dtype!r} is not available in this build "
+            f"(Ginkgo built without {dtype} support)."
+        )
+    return fn
+
+
+def _comm_handle(comm):
+    """Accept an mpi4py communicator or an already-converted Fortran MPI handle."""
+    if isinstance(comm, int):
+        return comm
+    py2f = getattr(comm, "py2f", None)
+    if py2f is None:
+        raise TypeError(
+            "comm must be an mpi4py communicator or an integer MPI_Comm handle "
+            "(as returned by comm.py2f())."
+        )
+    return py2f()
+
+
+def build_partition(exec, owners, num_parts):
+    _require_available()
+    return _distributed.build_partition(exec, owners, num_parts)
+
+
+def matrix(exec, comm, partition, rows, cols, vals, global_size, dtype="double"):
+    return _binding("matrix", dtype)(
+        exec, _comm_handle(comm), partition, rows, cols, vals, global_size
+    )
+
+
+def vector(exec, comm, partition, rows, vals, global_size, dtype="double"):
+    return _binding("vector", dtype)(
+        exec, _comm_handle(comm), partition, rows, vals, global_size
+    )
+
+
+_TYPESTR = {"double": "<f8", "float": "<f4", "half": "<f2"}
+_ITEMSIZE = {"double": 8, "float": 4, "half": 2}
+
+
+class _DeviceArray:
+    """Zero-copy ``__cuda_array_interface__`` view over a distributed vector's
+    local device buffer. Holds a reference to the source vector so the GPU
+    memory stays alive. Wrap with ``cupy.asarray(obj)`` or
+    ``numba.cuda.as_cuda_array(obj)``."""
+
+    def __init__(self, vector, ptr, shape, strides, typestr):
+        self._vector = vector  # keep-alive: GPU buffer is owned by the vector
+        self.__cuda_array_interface__ = {
+            "shape": shape,
+            "typestr": typestr,
+            "data": (ptr, False),  # (device pointer, read-only=False)
+            "strides": strides,
+            "version": 3,
+        }
+
+
+def vector_set_local(vector, vals, dtype="double"):
+    """Overwrite a distributed vector's processor-local values in place (no
+    reallocation, no re-distribution). ``vals`` may be a host numpy array or a
+    ``__cuda_array_interface__`` device array; its length must equal the
+    vector's local size and its entries must already be in Ginkgo's
+    processor-local ordering. Use to reuse a vector across solves instead of
+    rebuilding it with :func:`vector` every time."""
+    return _binding("vector_set_local", dtype)(vector, vals)
+
+
+def vector_local(vector, dtype="double", on_device=False):
+    """Processor-local part of a distributed vector.
+
+    on_device=False -> host numpy array (device->host copy).
+    on_device=True  -> a __cuda_array_interface__ wrapper over the device buffer
+                       (zero-copy); requires a CUDA-enabled build.
+    """
+    if not on_device:
+        return _binding("vector_local", dtype)(vector)
+    ptr, nrows, ncols, stride = _binding("vector_local_device", dtype)(vector)
+    itemsize = _ITEMSIZE[dtype]
+    if ncols == 1:
+        shape, strides = (nrows,), None  # contiguous
+    else:
+        # Ginkgo Dense is row-major with leading dimension `stride`.
+        shape, strides = (nrows, ncols), (stride * itemsize, itemsize)
+    return _DeviceArray(vector, ptr, shape, strides, _TYPESTR[dtype])
+
+
+if available:
+    # Re-export the typed bindings that this build actually compiled.
+    for _prefix in ("matrix", "vector", "vector_local", "vector_set_local"):
+        for _dtype in _VALID_DTYPES:
+            _name = f"{_prefix}_{_dtype}"
+            _fn = getattr(_distributed, _name, None)
+            if _fn is not None:
+                globals()[_name] = _fn
+    del _prefix, _dtype, _name, _fn
+
+
+__all__ = [
+    "available",
+    "Partition",
+    "build_partition",
+    "matrix",
+    "vector",
+    "vector_local",
+    "vector_set_local",
+]

--- a/src/pyGinkgo/distributed.py
+++ b/src/pyGinkgo/distributed.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
## Summary

This PR adds **distributed (MPI multi-GPU) support** to pyGinkgo, exposing Ginkgo's MPI-distributed matrix/vector types and enabling distributed linear solves across multiple ranks/GPUs.

## What's included

- **C++ bindings** (`src/cpp_bindings/distributed.cpp`) exposing Ginkgo's distributed matrix/vector and partition types, wired into the module via `python.cpp`.
- **Python API** (`src/pyGinkgo/distributed.py`) with a `distributed.available` guard so the bindings degrade gracefully when pyGinkgo is built without MPI.
- **Build integration**: `CMakeLists.txt` updates to optionally build with MPI support (`GINKGO_BUILD_MPI=ON`).
- **Example** (`examples/distributed_solver.py`): a minimal 1D Poisson problem solved with a distributed CG solver, where each MPI rank assembles only its own rows (PETSc-style), letting Ginkgo handle off-process communication.

## Usage

```bash
mpirun -n 4 python examples/distributed_solver.py
```

Requires pyGinkgo built with `GINKGO_BUILD_MPI=ON`.

## Notes

Happy to split this into smaller PRs or adjust the API to match project conventions — feedback welcome.
