### PR TITLE
Fix wheels build and publishing

### DIFF
--- a/.github/workflows/nightly_wheels.yml
+++ b/.github/workflows/nightly_wheels.yml
@@ -1,0 +1,98 @@
+name: Nightly wheels
+
+# Builds the full wheel set -- CPU and GPU -- once a day, but only when main
+# has actually moved since the last successful nightly. An unchanged tip would
+# otherwise rebuild byte-identical wheels across every job each night, and the
+# GPU variants take over an hour apiece.
+
+on:
+  schedule:
+    # 03:17 UTC. Deliberately off the hour: scheduled runs on the hour are
+    # heavily oversubscribed on GitHub's shared runners and get delayed.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Build even if main has not changed since the last nightly"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  # A nightly still running when the next one fires should finish rather than
+  # be killed halfway through.
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: Has main changed?
+    runs-on: ubuntu-latest
+    if: github.repository == 'Helmholtz-AI-Energy/pyGinkgo'
+    permissions:
+      contents: read
+      # Required to read this workflow's own previous runs.
+      actions: read
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Compare main against the last successful nightly
+        id: check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          # Scheduled runs always use the default branch, so GITHUB_SHA is the
+          # tip of main.
+          current="${GITHUB_SHA}"
+
+          # The most recent nightly that finished successfully -- including one
+          # that decided to skip, since that still means this SHA was accounted
+          # for. A failed nightly is not counted, so a failure retries the same
+          # commit the following night.
+          last="$(gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/nightly_wheels.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].head_sha // ""' 2>/dev/null || true)"
+
+          if [[ "${FORCE}" == "true" ]]; then
+            echo "Forced via workflow_dispatch; building ${current}."
+            changed=true
+          elif [[ -z "${last}" ]]; then
+            echo "No previous successful nightly found; building ${current}."
+            changed=true
+          elif [[ "${last}" == "${current}" ]]; then
+            echo "main is unchanged at ${current}; nothing to build."
+            changed=false
+          else
+            echo "main moved ${last} -> ${current}; building."
+            changed=true
+          fi
+
+          echo "changed=${changed}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "### Nightly wheels"
+            echo ""
+            echo "| | |"
+            echo "| --- | --- |"
+            echo "| tip of main | \`${current}\` |"
+            echo "| last nightly | \`${last:-none}\` |"
+            echo "| building | ${changed} |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  build:
+    name: Build
+    needs: check
+    if: needs.check.outputs.changed == 'true'
+    uses: ./.github/workflows/wheels.yml
+    with:
+      build_cpu: true
+      # The full set, GPU variants included: this only fires when main has
+      # actually moved, so the cost is per-change rather than per-night.
+      build_gpu: true
+      # Empty tag means scripts/set_package_version.py produces a nightly
+      # version rather than a stable one.
+      release_tag: ""

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -144,12 +144,23 @@ jobs:
             suffix: cuda128
             before_all: bash ci/install_cuda.sh 12.8
             config_settings: "override=cmake.args=[-DGINKGO_BUILD_CUDA=ON,-DCMAKE_CUDA_ARCHITECTURES=80;90,-DGINKGO_BUILD_MPI=OFF,-DGINKGO_BUILD_OMP=OFF,-DGINKGO_BUILD_HIP=OFF,-DGINKGO_BUILD_SYCL=OFF,-DGINKGO_BUILD_TESTS=OFF,-DGINKGO_BUILD_BENCHMARKS=OFF,-DGINKGO_BUILD_EXAMPLES=OFF]"
-            # The NVIDIA driver library libcuda.so.1 is provided by the user's
-            # installed driver and must not be bundled into the wheel. The CUDA
-            # runtime libraries are small enough to ship inside it.
+            # libcuda.so.1 comes from the user's NVIDIA driver and must never be
+            # bundled. The CUDA math libraries are excluded as well: Ginkgo links
+            # cublas, cusparse, curand and cufft, and bundling them produced a
+            # 1.995 GiB wheel -- 5 MiB under GitHub's 2 GiB release asset limit,
+            # which the next Ginkgo or CUDA update would have broken. The wheel
+            # therefore needs a CUDA 12.x installation on the host, the same way
+            # the ROCm variant needs a host ROCm. libcudart stays in the wheel:
+            # it is small, and keeping it matched to the build avoids a runtime
+            # version mismatch.
             repair_command: >
               LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
-              auditwheel -v repair --plat manylinux_2_34_x86_64 --exclude libcuda.so.1 -w {dest_dir} {wheel}
+              auditwheel -v repair --plat manylinux_2_34_x86_64
+              --exclude libcuda.so.1
+              --exclude 'libcublas.so*' --exclude 'libcublasLt.so*'
+              --exclude 'libcusparse.so*' --exclude 'libcurand.so*'
+              --exclude 'libcufft.so*' --exclude 'libnvJitLink.so*'
+              -w {dest_dir} {wheel}
             environment: >
               PATH=/usr/local/cuda/bin:$PATH
               LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
@@ -157,13 +168,23 @@ jobs:
               CUDAHOSTCXX=g++
               CUDAToolkit_ROOT=/usr/local/cuda
               PY_BUILD_CMAKE_VERBOSE=1
-          - label: CUDA 13.3
-            suffix: cuda133
-            before_all: bash ci/install_cuda.sh 13.3
+          # CUDA 13 needs its own variant because minor-version compatibility
+          # does not span major versions. 13.3 does not build: Ginkgo's batch
+          # solver headers fail under nvcc 13.3 with GCC 14 as host compiler
+          # ("need 'typename' before decltype" in GKO_DEFERRED_FACTORY_PARAMETER),
+          # so this tries the older 13.1 instead. Otherwise identical to 12.8.
+          - label: CUDA 13.1
+            suffix: cuda131
+            before_all: bash ci/install_cuda.sh 13.1
             config_settings: "override=cmake.args=[-DGINKGO_BUILD_CUDA=ON,-DCMAKE_CUDA_ARCHITECTURES=80;90,-DGINKGO_BUILD_MPI=OFF,-DGINKGO_BUILD_OMP=OFF,-DGINKGO_BUILD_HIP=OFF,-DGINKGO_BUILD_SYCL=OFF,-DGINKGO_BUILD_TESTS=OFF,-DGINKGO_BUILD_BENCHMARKS=OFF,-DGINKGO_BUILD_EXAMPLES=OFF]"
             repair_command: >
               LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH:-}"
-              auditwheel -v repair --plat manylinux_2_34_x86_64 --exclude libcuda.so.1 -w {dest_dir} {wheel}
+              auditwheel -v repair --plat manylinux_2_34_x86_64
+              --exclude libcuda.so.1
+              --exclude 'libcublas.so*' --exclude 'libcublasLt.so*'
+              --exclude 'libcusparse.so*' --exclude 'libcurand.so*'
+              --exclude 'libcufft.so*' --exclude 'libnvJitLink.so*'
+              -w {dest_dir} {wheel}
             environment: >
               PATH=/usr/local/cuda/bin:$PATH
               LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
@@ -174,11 +195,44 @@ jobs:
           - label: ROCm 6.4
             suffix: rocm64
             before_all: bash ci/install_rocm.sh 6.4
-            config_settings: "override=cmake.args=[-DGINKGO_BUILD_HIP=ON,-DCMAKE_HIP_ARCHITECTURES=gfx90a,-DGINKGO_BUILD_CUDA=OFF,-DGINKGO_BUILD_MPI=OFF,-DGINKGO_BUILD_OMP=OFF,-DGINKGO_BUILD_SYCL=OFF,-DGINKGO_BUILD_TESTS=OFF,-DGINKGO_BUILD_BENCHMARKS=OFF,-DGINKGO_BUILD_EXAMPLES=OFF]"
+            # --gcc-toolchain is required: ROCm's bundled clang only probes the
+            # standard prefixes for a GCC installation, while manylinux keeps its
+            # GCC in a gcc-toolset prefix, so the HIP compiler check otherwise
+            # fails with "'cmath' file not found". /opt/manylinux-gcc is the
+            # symlink install_rocm.sh points at whichever toolset is present.
+            config_settings: "override=cmake.args=[-DGINKGO_BUILD_HIP=ON,-DCMAKE_HIP_ARCHITECTURES=gfx90a,-DCMAKE_HIP_FLAGS=--gcc-toolchain=/opt/manylinux-gcc,-DGINKGO_BUILD_CUDA=OFF,-DGINKGO_BUILD_MPI=OFF,-DGINKGO_BUILD_OMP=OFF,-DGINKGO_BUILD_SYCL=OFF,-DGINKGO_BUILD_TESTS=OFF,-DGINKGO_BUILD_BENCHMARKS=OFF,-DGINKGO_BUILD_EXAMPLES=OFF]"
             # Unlike CUDA, the ROCm userspace stack is far too large to bundle
             # (rocBLAS alone ships multi-hundred-MB Tensile kernel archives), so
             # it is excluded wholesale and has to be present on the host at
             # import time -- typically via a `module load rocm` on HPC systems.
+            repair_command: >
+              LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH:-}"
+              auditwheel -v repair --plat manylinux_2_34_x86_64
+              --exclude 'libamdhip64.so*' --exclude 'libhsa-runtime64.so*'
+              --exclude 'libhsakmt.so*' --exclude 'libamd_comgr.so*'
+              --exclude 'libhiprtc.so*'
+              --exclude 'librocblas.so*' --exclude 'libhipblas.so*'
+              --exclude 'librocsparse.so*' --exclude 'libhipsparse.so*'
+              --exclude 'librocrand.so*' --exclude 'libhiprand.so*'
+              --exclude 'libroctx64.so*'
+              -w {dest_dir} {wheel}
+            environment: >
+              ROCM_PATH=/opt/rocm
+              PATH=/opt/rocm/bin:$PATH
+              LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH
+              CMAKE_PREFIX_PATH=/opt/rocm
+              HIP_PLATFORM=amd
+              PY_BUILD_CMAKE_VERBOSE=1
+          # ROCm 7 needs its own variant: the ROCm libraries are excluded from
+          # the wheel, so it links against the host's sonames and those carry
+          # the major version. 7.0 specifically, because AMD's rhel9 repository
+          # serves el8-built packages for 7.1 and 7.2, which do not belong in an
+          # AlmaLinux 9 manylinux image -- and 7.0 also sits below the HIP 7.1
+          # thrust-namespace issue Ginkgo works around.
+          - label: ROCm 7.0
+            suffix: rocm70
+            before_all: bash ci/install_rocm.sh 7.0
+            config_settings: "override=cmake.args=[-DGINKGO_BUILD_HIP=ON,-DCMAKE_HIP_ARCHITECTURES=gfx90a,-DCMAKE_HIP_FLAGS=--gcc-toolchain=/opt/manylinux-gcc,-DGINKGO_BUILD_CUDA=OFF,-DGINKGO_BUILD_MPI=OFF,-DGINKGO_BUILD_OMP=OFF,-DGINKGO_BUILD_SYCL=OFF,-DGINKGO_BUILD_TESTS=OFF,-DGINKGO_BUILD_BENCHMARKS=OFF,-DGINKGO_BUILD_EXAMPLES=OFF]"
             repair_command: >
               LD_LIBRARY_PATH="/opt/rocm/lib:${LD_LIBRARY_PATH:-}"
               auditwheel -v repair --plat manylinux_2_34_x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,18 @@ set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
 # copy all generated files to pyGinkgo that makes testing and installing easier
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${PROJECT_NAME})
 
+# Multi-config generators (Visual Studio) append the configuration name to the
+# output directory, which would put the extension module in pyGinkgo/Release/
+# instead of next to the Python sources. It would then be packaged one level too
+# deep and fail to import as pyGinkgo.pyGinkgoBindings. Pin every configuration
+# to the same directory. CMAKE_CONFIGURATION_TYPES is empty for single-config
+# generators, so this is a no-op there.
+foreach(config IN LISTS CMAKE_CONFIGURATION_TYPES)
+  string(TOUPPER "${config}" config_upper)
+  set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${config_upper}
+      ${CMAKE_BINARY_DIR}/${PROJECT_NAME})
+endforeach()
+
 # Find OpenMPI find_package(MPI REQUIRED)
 
 # Find pybind11
@@ -179,11 +191,29 @@ add_subdirectory(tests/pyGinkgo)
 if(APPLE)
   set(CMAKE_MACOSX_RPATH 1)
 endif()
-set(CMAKE_INSTALL_RPATH ${Python_SITELIB}/${PROJECT_NAME})
+# The extension module and the Ginkgo shared libraries are installed next to
+# each other, so a relative RPATH keeps the result relocatable. An absolute
+# RPATH into the build environment would not survive wheel packaging.
+if(APPLE)
+  set(CMAKE_INSTALL_RPATH "@loader_path")
+else()
+  set(CMAKE_INSTALL_RPATH "$ORIGIN")
+endif()
 
-message(STATUS "Install path: ${Python_SITELIB}")
-install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-        DESTINATION ${Python_SITELIB})
+# Install destinations must stay RELATIVE. CMake ignores CMAKE_INSTALL_PREFIX
+# whenever a DESTINATION is absolute, and py-build-cmake relies on that prefix
+# to redirect the install into the wheel staging directory -- an absolute
+# ${Python_SITELIB} destination silently installs into the isolated build
+# environment instead, producing a wheel with no binaries in it. Defaulting the
+# prefix to site-packages keeps a plain `cmake --install .` behaving as before.
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX
+      "${Python_SITELIB}"
+      CACHE PATH "Where the pyGinkgo package is installed" FORCE)
+endif()
+
+message(STATUS "Install path: ${CMAKE_INSTALL_PREFIX}")
+install(DIRECTORY ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} DESTINATION ".")
 install(
   IMPORTED_RUNTIME_ARTIFACTS
   ginkgo
@@ -194,4 +224,13 @@ install(
   ginkgo_dpcpp
   ginkgo_reference
   DESTINATION
-  ${Python_SITELIB}/${PROJECT_NAME})
+  ${PROJECT_NAME})
+
+# On MSVC/MINGW shared builds Ginkgo splits its core out into a separate
+# ginkgo_core library to work around the LNK1189 exported-symbol limit; see
+# `set(ginkgo_core ...)` in ginkgo's core/CMakeLists.txt. Everywhere else
+# ginkgo_core *is* ginkgo, so the target only exists on Windows -- where
+# ginkgo.dll imports it and the package is unimportable without it.
+if(TARGET ginkgo_core)
+  install(IMPORTED_RUNTIME_ARTIFACTS ginkgo_core DESTINATION ${PROJECT_NAME})
+endif()

--- a/README.md
+++ b/README.md
@@ -52,22 +52,21 @@ as `+cuda128`, and PyPI rejects local version identifiers. They are attached to
 the matching [GitHub Release](https://github.com/Helmholtz-AI-Energy/pyGinkgo/releases)
 instead, and are installed directly by URL:
 
-Two CUDA variants are built, one per CUDA major version. Pick the one matching
-the CUDA installation your driver supports — a 12.x wheel will not run against a
-CUDA 13 installation or the reverse, because minor-version compatibility does
-not span major versions:
+Two variants are built, one per CUDA major version. Pick the one matching your
+CUDA installation — minor-version compatibility spans a major line but not
+across one, so a 12.x wheel will not run against CUDA 13 or the reverse:
 
-| Variant | Suffix | NVIDIA driver |
-| --- | --- | --- |
-| CUDA 12.8 | `+cuda128` | R525+ (CUDA 12 minor-version compatibility) |
-| CUDA 13.3 | `+cuda133` | R580+ |
+| Variant | Suffix | Works with | NVIDIA driver |
+| --- | --- | --- | --- |
+| CUDA 12.8 | `+cuda128` | any CUDA 12.x | R525+ |
+| CUDA 13.1 | `+cuda131` | any CUDA 13.x | R580+ |
 
 ```bash
 # CUDA 12.8, CPython 3.12, Linux x86-64
 pip install https://github.com/Helmholtz-AI-Energy/pyGinkgo/releases/download/v0.0.1/pyGinkgo-0.0.1+cuda128-cp312-cp312-manylinux_2_34_x86_64.whl
 
-# CUDA 13.3, same platform
-pip install https://github.com/Helmholtz-AI-Energy/pyGinkgo/releases/download/v0.0.1/pyGinkgo-0.0.1+cuda133-cp312-cp312-manylinux_2_34_x86_64.whl
+# CUDA 13.1, same platform
+pip install https://github.com/Helmholtz-AI-Energy/pyGinkgo/releases/download/v0.0.1/pyGinkgo-0.0.1+cuda131-cp312-cp312-manylinux_2_34_x86_64.whl
 ```
 
 Both variants are otherwise identical, and narrower than the CPU wheels:
@@ -77,33 +76,58 @@ Both variants are otherwise identical, and narrower than the CPU wheels:
 | OS | Linux x86-64, glibc >= 2.34 (Ubuntu 22.04+, RHEL/Rocky 9+, Debian 12+) |
 | Python | CPython 3.12 only |
 | GPU | compute capability 8.0 (Ampere, e.g. A100/A30) and 9.0 (Hopper, e.g. H100) |
-| CUDA toolkit | not required at runtime — the CUDA runtime libraries are bundled |
+| CUDA math libraries | **required on the host**, matching the variant's major version |
 
-Only `libcuda.so.1` is deliberately excluded from the wheel, since it is provided
-by the installed NVIDIA driver. Both variants also embed PTX, so newer GPU
-architectures should work through JIT compilation, but this is not tested.
+The CUDA math libraries are *not* bundled: Ginkgo links cuBLAS, cuSPARSE, cuRAND
+and cuFFT, and shipping them produced a 2 GB wheel. The wheel links against the
+host's CUDA installation instead, so a matching toolkit must be installed and on
+the loader path — on HPC systems this usually means loading the matching module
+before importing pyGinkgo:
+
+```bash
+module load cuda/12          # or: export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
+```
+
+`libcuda.so.1` is excluded too, since it is provided by the installed NVIDIA
+driver, while `libcudart` *is* bundled so the CUDA runtime stays matched to the
+build. The wheel also embeds PTX, so newer GPU architectures should work through
+JIT compilation, but this is not tested.
 
 #### ROCm wheels (from GitHub Releases)
 
-ROCm wheels are published alongside the CUDA ones, with a `+rocm64` suffix:
+ROCm wheels are published alongside the CUDA ones. As with CUDA, there is one
+variant per major version — the ROCm libraries are not bundled, so the wheel
+links against the host's sonames and those carry the major version. A ROCm 6
+wheel will not load against a ROCm 7 installation:
+
+| Variant | Suffix | Works with |
+| --- | --- | --- |
+| ROCm 6.4 | `+rocm64` | any ROCm 6.x |
+| ROCm 7.0 | `+rocm70` | any ROCm 7.x |
 
 ```bash
 # ROCm 6.4, CPython 3.12, Linux x86-64, AMD CDNA2 (gfx90a)
 pip install https://github.com/Helmholtz-AI-Energy/pyGinkgo/releases/download/v0.0.1/pyGinkgo-0.0.1+rocm64-cp312-cp312-manylinux_2_34_x86_64.whl
+
+# ROCm 7.0, same platform
+pip install https://github.com/Helmholtz-AI-Energy/pyGinkgo/releases/download/v0.0.1/pyGinkgo-0.0.1+rocm70-cp312-cp312-manylinux_2_34_x86_64.whl
 ```
+
+Both variants are otherwise identical:
 
 | Requirement | Value |
 | --- | --- |
 | OS | Linux x86-64, glibc >= 2.34 (Ubuntu 22.04+, RHEL/Rocky 9+, Debian 12+) |
 | Python | CPython 3.12 only |
 | GPU | gfx90a (CDNA2, e.g. MI210/MI250X) |
-| ROCm runtime | **required on the host**, 6.4.x |
+| ROCm runtime | **required on the host**, matching the variant's major version |
 
-Note the difference from the CUDA wheel: the ROCm userspace libraries are *not*
-bundled, because rocBLAS alone ships hundreds of megabytes of Tensile kernels.
-The wheel links against the host's ROCm installation, so ROCm 6.4 must be
-installed and on the loader path — on HPC systems this usually means loading the
-matching module before importing pyGinkgo:
+Note the difference from the CUDA wheels: *all* the ROCm userspace libraries are
+excluded, not just the math ones, because rocBLAS alone ships hundreds of
+megabytes of Tensile kernels. The wheel links against the host's ROCm
+installation, so a matching ROCm must be installed and on the loader path — on
+HPC systems this usually means loading the matching module before importing
+pyGinkgo:
 
 ```bash
 module load rocm/6.4          # or: export LD_LIBRARY_PATH=/opt/rocm/lib:$LD_LIBRARY_PATH

--- a/ci/check_installed_wheel.py
+++ b/ci/check_installed_wheel.py
@@ -15,11 +15,51 @@ exercised, since GitHub-hosted runners have no GPU.
 from __future__ import annotations
 
 from importlib import metadata
+from importlib import util as _importlib_util
 from pathlib import Path
 import re
+import sys
 
-import pyGinkgo
-import pyGinkgo.pyGinkgoBindings as pGB
+
+def _report_windows_load_failure(error: BaseException) -> None:
+    """Name the library Windows could not resolve.
+
+    "DLL load failed ... The specified module could not be found" never says
+    which module is missing, which makes a CI-only failure very hard to act on.
+    Loading each bundled binary explicitly by absolute path pinpoints the one
+    that fails, and its dependency chain along with it.
+    """
+    import ctypes
+
+    print(f"Import failed: {error}", file=sys.stderr)
+
+    spec = _importlib_util.find_spec("pyGinkgo")
+    if spec is None or not spec.submodule_search_locations:
+        print("Could not locate the installed pyGinkgo package.", file=sys.stderr)
+        return
+
+    package_dir = Path(list(spec.submodule_search_locations)[0])
+    print(f"Package directory: {package_dir}", file=sys.stderr)
+    for entry in sorted(package_dir.iterdir()):
+        print(f"    {entry.name}", file=sys.stderr)
+
+    print("Loading each bundled binary by absolute path:", file=sys.stderr)
+    for binary in sorted(package_dir.glob("*.dll")) + sorted(package_dir.glob("*.pyd")):
+        try:
+            ctypes.WinDLL(str(binary))
+        except OSError as exc:
+            print(f"    FAIL {binary.name}: {exc}", file=sys.stderr)
+        else:
+            print(f"    ok   {binary.name}", file=sys.stderr)
+
+
+try:
+    import pyGinkgo
+    import pyGinkgo.pyGinkgoBindings as pGB
+except ImportError as error:
+    if sys.platform == "win32":
+        _report_windows_load_failure(error)
+    raise
 
 
 PROJECT_NAME = re.compile(r'(?m)^name = "([^"]+)"$')

--- a/ci/install_rocm.sh
+++ b/ci/install_rocm.sh
@@ -84,3 +84,28 @@ fi
 
 ln -sfn "${rocm_root}" /opt/rocm
 "/opt/rocm/bin/hipconfig" --version
+
+# ROCm's bundled clang only probes the standard prefixes when looking for a GCC
+# installation, but the manylinux image keeps its GCC in a gcc-toolset prefix
+# (see DEVTOOLSET_ROOTPATH in pypa/manylinux's Dockerfile) and merely puts it on
+# PATH -- so clang finds no libstdc++ and the HIP compiler check fails with
+# "'cmath' file not found". Expose the toolchain at a fixed path so the build can
+# pass --gcc-toolchain=/opt/manylinux-gcc without hard-coding a GCC version.
+gcc_root=""
+shopt -s nullglob
+for candidate in /opt/rh/gcc-toolset-*/root/usr; do
+    [[ -d "${candidate}/include/c++" ]] && gcc_root="${candidate}"
+done
+shopt -u nullglob
+
+if [[ -z "${gcc_root}" ]]; then
+    echo "Could not find a GCC toolset providing C++ headers." >&2
+    echo "c++ resolves to: $(command -v c++ 2>/dev/null || echo none)" >&2
+    echo "  -> $(readlink -f "$(command -v c++)" 2>/dev/null || echo none)" >&2
+    echo "Candidates under /opt/rh:" >&2
+    ls -d /opt/rh/* 2>/dev/null >&2 || echo "  (none)" >&2
+    exit 1
+fi
+
+ln -sfn "${gcc_root}" /opt/manylinux-gcc
+echo "Using GCC toolchain at ${gcc_root}"

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -2,6 +2,40 @@
 #
 # SPDX-License-Identifier: MIT
 
+import os as _os
+import sys as _sys
+
+# The Ginkgo shared libraries ship next to the extension module. On Windows a
+# DLL's own imports are resolved by name against the default search path, which
+# does not include this package directory, so loading ginkgo.dll cold fails even
+# though the ginkgo_* libraries it imports sit right beside it. Note that
+# os.add_dll_directory does not help: CPython loads extension modules with
+# LOAD_WITH_ALTERED_SEARCH_PATH, which does not consult those directories.
+#
+# Pre-loading each bundled library by absolute path does work -- once a library
+# is in the process, later imports of it resolve by name. The link order is not
+# known here, so keep retrying until a pass loads nothing new.
+if _sys.platform == "win32":
+    import ctypes as _ctypes
+    import glob as _glob
+
+    _package_dir = _os.path.dirname(_os.path.abspath(__file__))
+    if hasattr(_os, "add_dll_directory"):
+        _os.add_dll_directory(_package_dir)
+
+    _pending = _glob.glob(_os.path.join(_package_dir, "*.dll"))
+    while _pending:
+        _unresolved = []
+        for _library in _pending:
+            try:
+                _ctypes.WinDLL(_library)
+            except OSError:
+                _unresolved.append(_library)
+        if len(_unresolved) == len(_pending):
+            # No progress this pass; let the import below surface the error.
+            break
+        _pending = _unresolved
+
 from .pyGinkgoBindings import \
     base, factorization, logger, matrix
 


### PR DESCRIPTION
This PR adjusts the CMake build/install layout to make the built Python extension and dependent shared libraries package correctly (notably for wheel builds and multi-config generators like Visual Studio), and to keep the installed artifacts relocatable.

## Changes:

- Pin multi-config build outputs to a single directory to avoid config-suffixed subfolders that break import/package layout.
- Switch install RPATH to a relative form (@loader_path / $ORIGIN) to support relocatable wheels.
- Make install destinations relative and default CMAKE_INSTALL_PREFIX to Python site-packages so wheel staging via CMAKE_INSTALL_PREFIX works correctly.