### PR TITLE
improve reporting on non existing mtx files

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,15 @@ This will generate the stubs for the C++ code in the `pyGinkgoBindings` module i
 
 ## Usage
 
-Usage examples can be found in [examples](examples) directory. Here's a simple example demonstrating how to use pyGinkgo to perform sparse matrix-vector multiplication:
+Usage examples can be found in [examples](examples) directory. Here's a simple example demonstrating how to use pyGinkgo to perform sparse matrix-vector multiplication.
+
+It reads a matrix in [Matrix Market](https://math.nist.gov/MatrixMarket/formats.html)
+format. The example below uses `m1.mtx` from this repository — if you installed
+pyGinkgo from PyPI you will not have it locally, so fetch it first:
+
+```bash
+curl -LO https://raw.githubusercontent.com/Helmholtz-AI-Energy/pyGinkgo/main/examples/m1.mtx
+```
 
 ```python
 import pyGinkgo as pg
@@ -265,7 +273,8 @@ import numpy as np
 # Device initialization
 dev = pg.device("cuda")
 
-# Initialize matrix and tensors
+# Initialize matrix and tensors. The path is relative to the working
+# directory, so run this from wherever m1.mtx actually is.
 fn = 'm1.mtx'
 
 A = pg.read(device=dev, path=fn, dtype="double", format="Csr")

--- a/src/pyGinkgo/core.py
+++ b/src/pyGinkgo/core.py
@@ -93,7 +93,24 @@ def read(
 
     # Processing filepath
     filepath = os.path.abspath(path)
-    
+
+    # Ginkgo is handed a std::ifstream that it does not check for open failure,
+    # so any problem opening the file surfaces as a confusing
+    # "error when reading the header line" from the Matrix Market parser.
+    # Probe it here instead. Opening is exactly what Ginkgo goes on to do, and
+    # it reports the real reason -- missing, unreadable, a directory -- where
+    # os.path.isfile() collapses all of them (and a stat() denied by an
+    # unsearchable parent directory) into a single False.
+    try:
+        with open(filepath, "rb"):
+            pass
+    except OSError as error:
+        raise type(error)(
+            f"Cannot read matrix file {filepath!r}" +
+            ("" if os.path.isabs(path) else f" (resolved from {path!r})") +
+            f": {error.strerror}"
+        ) from error
+
     executor = pg.device(device)
 
     # Checking if the format is valid

--- a/tests/pyGinkgo/test_core.py
+++ b/tests/pyGinkgo/test_core.py
@@ -115,6 +115,66 @@ class TestCore:
                 device=self.executor,
             )
 
+    def test_read_rejects_missing_file(self, tmp_path):
+        # Without an explicit check the missing file reaches Ginkgo, which
+        # reports it as "error when reading the header line" from the Matrix
+        # Market parser -- see issue #120.
+        with pytest.raises(FileNotFoundError, match="Cannot read matrix file"):
+            pg.read(
+                str(tmp_path / "does_not_exist.mtx"),
+                format="Coo",
+                dtype=self.data_type,
+                itype="int32",
+                device=self.executor,
+            )
+
+    def test_read_reports_the_relative_path_it_was_given(self, tmp_path, monkeypatch):
+        # A bare relative path resolving somewhere unexpected is what made
+        # issue #120 confusing, so the message has to name both the path that
+        # was passed and the absolute path it resolved to.
+        monkeypatch.chdir(tmp_path)
+        with pytest.raises(
+            FileNotFoundError, match=r"resolved from 'does_not_exist\.mtx'"
+        ):
+            pg.read(
+                "does_not_exist.mtx",
+                format="Coo",
+                dtype=self.data_type,
+                itype="int32",
+                device=self.executor,
+            )
+
+    def test_read_rejects_a_directory(self, tmp_path):
+        with pytest.raises(IsADirectoryError, match="Cannot read matrix file"):
+            pg.read(
+                str(tmp_path),
+                format="Coo",
+                dtype=self.data_type,
+                itype="int32",
+                device=self.executor,
+            )
+
+    @pytest.mark.skipif(
+        os.name != "posix" or os.geteuid() == 0,
+        reason="needs POSIX file permissions and a non-root user",
+    )
+    def test_read_rejects_unreadable_file(self, tmp_path):
+        unreadable = tmp_path / "unreadable.mtx"
+        unreadable.write_text("%%MatrixMarket matrix coordinate real general\n")
+        unreadable.chmod(0o000)
+        try:
+            with pytest.raises(PermissionError, match="Cannot read matrix file"):
+                pg.read(
+                    str(unreadable),
+                    format="Coo",
+                    dtype=self.data_type,
+                    itype="int32",
+                    device=self.executor,
+                )
+        finally:
+            # Leave it removable by tmp_path cleanup.
+            unreadable.chmod(0o644)
+
     def test_generate_solver_can_apply_solver(self):
         solver_args = {
             "type": "solver::Cg",


### PR DESCRIPTION
Improves error reporting for missing or unreadable Matrix Market files and clarifies README setup instructions.

## Changes:

- Adds matrix-file validation before parsing.
- Documents downloading and locating the example matrix.