### PR TITLE
Add Imad Kissami to AUTHORS.md

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,4 +7,5 @@ Gregor Olenik <gregor.olenik@kit.edu>, Karlsruhe Institute of Technology\
 Keshvi Tuteja <keshvi.tuteja@kit.edu>, Karlsruhe Institute of Technology\
 Rickard Holmberg <rickard.holmberg@novatronfusion.com>, Novatron Fusion Group\
 Yu-Hsiang Tsai <yhmtsai@gmail.com>, Technical University of Munich\
-Kai-Hui You <kai-hui.you@tum.de>, Technical University of Munich
+Kai-Hui You <kai-hui.you@tum.de>, Technical University of Munich\
+Imad Kissami <imad.kissami@um6p.ma>, Mohammed VI Polytechnic University

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
-# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 cmake_minimum_required(VERSION 3.20)
 project(pyGinkgo)

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Imad Kissami
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
-# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/python.cpp

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Imad Kissami
+// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
-// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
-// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
-# SPDX-FileCopyrightText: 2026 Imad Kissami
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/pyGinkgo/distributed.py
+++ b/src/pyGinkgo/distributed.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Imad Kissami
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
Follow-up to @greole's review comment on #116 ("Please add yourself to the AUTHORS.md as a pyGinkgo author instead"), which was not addressed before the PR got merged.

- Adds me to `AUTHORS.md`.
- Removes the separate `SPDX-FileCopyrightText: 2026 Imad Kissami` lines added in #116 and restores the `pyGinkgo authors` copyright header on those files.

Based on `feat/mpi` since the distributed-bindings files only exist there.