### PR TITLE
Ginkgo MPI bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,5 @@ cython_debug/
 src/pyGinkgo/pyGinkgoBindings/
 
 .venv_p
+.py-build-cmake_cache/
+py-build-cmake.local.toml

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,4 +7,5 @@ Gregor Olenik <gregor.olenik@kit.edu>, Karlsruhe Institute of Technology\
 Keshvi Tuteja <keshvi.tuteja@kit.edu>, Karlsruhe Institute of Technology\
 Rickard Holmberg <rickard.holmberg@novatronfusion.com>, Novatron Fusion Group\
 Yu-Hsiang Tsai <yhmtsai@gmail.com>, Technical University of Munich\
-Kai-Hui You <kai-hui.you@tum.de>, Technical University of Munich
+Kai-Hui You <kai-hui.you@tum.de>, Technical University of Munich\
+Imad Kissami <imad.kissami@um6p.ma>, Mohammed VI Polytechnic University

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 cmake_minimum_required(VERSION 3.20)
 project(pyGinkgo)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,33 @@ target_link_libraries(pyGinkgoBindings PRIVATE Ginkgo::ginkgo)
 target_link_libraries(pyGinkgoBindings PUBLIC nlohmann_json::nlohmann_json)
 set_property(TARGET pyGinkgoBindings PROPERTY CXX_STANDARD 14)
 
+# MPI / distributed bindings: only built when Ginkgo is compiled with MPI.
+# FetchContent builds expose GINKGO_BUILD_MPI as a cache variable, while installed
+# Ginkgo packages may only expose it through target compile definitions.
+set(PYGINKGO_GINKGO_HAS_MPI OFF)
+if(DEFINED GINKGO_BUILD_MPI AND GINKGO_BUILD_MPI)
+  set(PYGINKGO_GINKGO_HAS_MPI ON)
+endif()
+if(TARGET Ginkgo::ginkgo)
+  get_target_property(_ginkgo_compile_defs Ginkgo::ginkgo INTERFACE_COMPILE_DEFINITIONS)
+  if(_ginkgo_compile_defs)
+    foreach(_ginkgo_def IN LISTS _ginkgo_compile_defs)
+      if(_ginkgo_def MATCHES "(^|[<:])GINKGO_BUILD_MPI($|[>:])")
+        set(PYGINKGO_GINKGO_HAS_MPI ON)
+      endif()
+    endforeach()
+  endif()
+endif()
+
+if(PYGINKGO_GINKGO_HAS_MPI)
+  find_package(MPI REQUIRED COMPONENTS CXX)
+  target_compile_definitions(pyGinkgoBindings PRIVATE GINKGO_BUILD_MPI)
+  target_link_libraries(pyGinkgoBindings PRIVATE MPI::MPI_CXX)
+  message(STATUS "pyGinkgo: MPI-distributed bindings enabled")
+else()
+  message(STATUS "pyGinkgo: MPI-distributed bindings disabled")
+endif()
+
 # Disable false positive warnings from GCC (>= 12.4 and <
 # 13)(https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115824 and
 # https://github.com/pybind/pybind11/issues/5224)
@@ -158,7 +185,8 @@ set(PYGINKGO_PYTHON_FILES
     ${PROJECT_SOURCE_DIR}/src/pyGinkgo/device.py
     ${PROJECT_SOURCE_DIR}/src/pyGinkgo/solver.py
     ${PROJECT_SOURCE_DIR}/src/pyGinkgo/rayleigh_ritz.py
-    ${PROJECT_SOURCE_DIR}/src/pyGinkgo/preconditioner.py)
+    ${PROJECT_SOURCE_DIR}/src/pyGinkgo/preconditioner.py
+    ${PROJECT_SOURCE_DIR}/src/pyGinkgo/distributed.py)
 # TODO: it seems reasonable to be to start using glob recuse above
 
 add_custom_target(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,14 +99,16 @@ target_link_libraries(pyGinkgoBindings PUBLIC nlohmann_json::nlohmann_json)
 set_property(TARGET pyGinkgoBindings PROPERTY CXX_STANDARD 14)
 
 # MPI / distributed bindings: only built when Ginkgo is compiled with MPI.
-# FetchContent builds expose GINKGO_BUILD_MPI as a cache variable, while installed
-# Ginkgo packages may only expose it through target compile definitions.
+# FetchContent builds expose GINKGO_BUILD_MPI as a cache variable, while
+# installed Ginkgo packages may only expose it through target compile
+# definitions.
 set(PYGINKGO_GINKGO_HAS_MPI OFF)
 if(DEFINED GINKGO_BUILD_MPI AND GINKGO_BUILD_MPI)
   set(PYGINKGO_GINKGO_HAS_MPI ON)
 endif()
 if(TARGET Ginkgo::ginkgo)
-  get_target_property(_ginkgo_compile_defs Ginkgo::ginkgo INTERFACE_COMPILE_DEFINITIONS)
+  get_target_property(_ginkgo_compile_defs Ginkgo::ginkgo
+                      INTERFACE_COMPILE_DEFINITIONS)
   if(_ginkgo_compile_defs)
     foreach(_ginkgo_def IN LISTS _ginkgo_compile_defs)
       if(_ginkgo_def MATCHES "(^|[<:])GINKGO_BUILD_MPI($|[>:])")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
-# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 cmake_minimum_required(VERSION 3.20)
 project(pyGinkgo)

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -36,7 +36,7 @@ if not pg.distributed.available:
 
 # ---------------------------------------------------------------- parameters
 N = 16                       # global system size
-executor = pg.device("cpu")  # "cpu", "omp", or "cuda" / "cuda:0"
+executor = pg.device("cuda")  # "cpu", "omp", or "cuda" / "cuda:0"
 value = "double"             # matches np.float64
 
 # ----------------------------------------------------- row distribution (1D)

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 Imad Kissami
+#
+# SPDX-License-Identifier: MIT
+
+"""Minimal distributed pyGinkgo example.
+
+Solves the 1D Poisson problem ``A x = b`` where ``A`` is the N x N tridiagonal
+Laplacian (diag = 2, off-diag = -1) and ``b = 1``, using Ginkgo's MPI-distributed
+matrix/vector and a CG solver.
+
+Each MPI rank owns a contiguous block of rows and assembles ONLY its own rows
+(like PETSc): Ginkgo handles the off-process communication during the solve.
+
+Run with:
+    mpirun -n 4 python examples/distributed_solver.py
+
+Requires pyGinkgo built with MPI support (GINKGO_BUILD_MPI=ON).
+"""
+
+import json
+
+import numpy as np
+from mpi4py import MPI
+
+import pyGinkgo as pg
+from pyGinkgo import pyGinkgoBindings as pGB
+
+comm = MPI.COMM_WORLD
+rank = comm.Get_rank()
+size = comm.Get_size()
+
+if not pg.distributed.available:
+    raise RuntimeError(
+        "pyGinkgo was built without MPI support (GINKGO_BUILD_MPI=ON). "
+        "The distributed bindings are unavailable.")
+
+# ---------------------------------------------------------------- parameters
+N = 16                       # global system size
+executor = pg.device("cpu")  # "cpu", "omp", or "cuda" / "cuda:0"
+value = "double"             # matches np.float64
+
+# ----------------------------------------------------- row distribution (1D)
+# owners[g] = rank that owns global row g. Split the N rows into contiguous
+# blocks, one per rank.
+counts = [N // size + (1 if r < N % size else 0) for r in range(size)]
+offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.int32)
+start, end = offsets[rank], offsets[rank + 1]
+owned_rows = np.arange(start, end, dtype=np.int32)
+
+owners = np.empty(N, dtype=np.int32)
+for r in range(size):
+    owners[offsets[r]:offsets[r + 1]] = r
+
+partition = pg.distributed.build_partition(executor, owners, size)
+
+# --------------------------------------------- local assembly (owned rows only)
+# 1D Laplacian stencil: row i has 2 on the diagonal and -1 to its neighbours.
+# Indices are 0-based GLOBAL indices.
+rows, cols, vals = [], [], []
+for i in range(start, end):
+    rows.append(i); cols.append(i); vals.append(2.0)
+    if i > 0:
+        rows.append(i); cols.append(i - 1); vals.append(-1.0)
+    if i < N - 1:
+        rows.append(i); cols.append(i + 1); vals.append(-1.0)
+
+rows = np.asarray(rows, dtype=np.int32)
+cols = np.asarray(cols, dtype=np.int32)
+vals = np.asarray(vals, dtype=np.float64)
+
+A = pg.distributed.matrix(executor, comm, partition, rows, cols, vals, N,
+                          dtype=value)
+
+# ------------------------------------------------------ distributed RHS / sol
+b_local = np.ones(owned_rows.size, dtype=np.float64)        # b = 1
+x_local = np.zeros(owned_rows.size, dtype=np.float64)       # initial guess 0
+
+b = pg.distributed.vector(executor, comm, partition, owned_rows, b_local, N,
+                          dtype=value)
+x = pg.distributed.vector(executor, comm, partition, owned_rows, x_local, N,
+                          dtype=value)
+
+# ------------------------------------------------------------------- solve
+solver_args = json.dumps({
+    "type": "solver::Cg",
+    "criteria": [
+        {"type": "Iteration", "max_iters": 1000},
+        {"type": "ResidualNorm", "reduction_factor": 1e-10},
+    ],
+})
+
+logger = pGB.solver.config_solve_double(executor, A, b, x, solver_args)
+
+# ----------------------------------------------------------------- results
+# Each rank reads its own slice of the solution (processor-local part).
+sol_local = pg.distributed.vector_local(x, dtype=value)
+
+if rank == 0:
+    print(f"[pyGinkgo distributed] N={N} ranks={size} "
+          f"converged={logger.has_converged()} "
+          f"iters={logger.get_num_iterations()}")
+
+# Gather the full solution on rank 0 just to print it (only for this demo).
+full = comm.gather(np.asarray(sol_local).ravel(), root=0)
+if rank == 0:
+    x_full = np.concatenate(full)
+    print("solution:", np.array2string(x_full, precision=4, suppress_small=True))

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -32,12 +32,13 @@ size = comm.Get_size()
 if not pg.distributed.available:
     raise RuntimeError(
         "pyGinkgo was built without MPI support (GINKGO_BUILD_MPI=ON). "
-        "The distributed bindings are unavailable.")
+        "The distributed bindings are unavailable."
+    )
 
 # ---------------------------------------------------------------- parameters
-N = 16                       # global system size
+N = 16  # global system size
 executor = pg.device("cuda")  # "cpu", "omp", or "cuda" / "cuda:0"
-value = "double"             # matches np.float64
+value = "double"  # matches np.float64
 
 # ----------------------------------------------------- row distribution (1D)
 # owners[g] = rank that owns global row g. Split the N rows into contiguous
@@ -49,7 +50,7 @@ owned_rows = np.arange(start, end, dtype=np.int32)
 
 owners = np.empty(N, dtype=np.int32)
 for r in range(size):
-    owners[offsets[r]:offsets[r + 1]] = r
+    owners[offsets[r] : offsets[r + 1]] = r
 
 partition = pg.distributed.build_partition(executor, owners, size)
 
@@ -58,36 +59,45 @@ partition = pg.distributed.build_partition(executor, owners, size)
 # Indices are 0-based GLOBAL indices.
 rows, cols, vals = [], [], []
 for i in range(start, end):
-    rows.append(i); cols.append(i); vals.append(2.0)
+    rows.append(i)
+    cols.append(i)
+    vals.append(2.0)
     if i > 0:
-        rows.append(i); cols.append(i - 1); vals.append(-1.0)
+        rows.append(i)
+        cols.append(i - 1)
+        vals.append(-1.0)
     if i < N - 1:
-        rows.append(i); cols.append(i + 1); vals.append(-1.0)
+        rows.append(i)
+        cols.append(i + 1)
+        vals.append(-1.0)
 
 rows = np.asarray(rows, dtype=np.int32)
 cols = np.asarray(cols, dtype=np.int32)
 vals = np.asarray(vals, dtype=np.float64)
 
-A = pg.distributed.matrix(executor, comm, partition, rows, cols, vals, N,
-                          dtype=value)
+A = pg.distributed.matrix(executor, comm, partition, rows, cols, vals, N, dtype=value)
 
 # ------------------------------------------------------ distributed RHS / sol
-b_local = np.ones(owned_rows.size, dtype=np.float64)        # b = 1
-x_local = np.zeros(owned_rows.size, dtype=np.float64)       # initial guess 0
+b_local = np.ones(owned_rows.size, dtype=np.float64)  # b = 1
+x_local = np.zeros(owned_rows.size, dtype=np.float64)  # initial guess 0
 
-b = pg.distributed.vector(executor, comm, partition, owned_rows, b_local, N,
-                          dtype=value)
-x = pg.distributed.vector(executor, comm, partition, owned_rows, x_local, N,
-                          dtype=value)
+b = pg.distributed.vector(
+    executor, comm, partition, owned_rows, b_local, N, dtype=value
+)
+x = pg.distributed.vector(
+    executor, comm, partition, owned_rows, x_local, N, dtype=value
+)
 
 # ------------------------------------------------------------------- solve
-solver_args = json.dumps({
-    "type": "solver::Cg",
-    "criteria": [
-        {"type": "Iteration", "max_iters": 1000},
-        {"type": "ResidualNorm", "reduction_factor": 1e-10},
-    ],
-})
+solver_args = json.dumps(
+    {
+        "type": "solver::Cg",
+        "criteria": [
+            {"type": "Iteration", "max_iters": 1000},
+            {"type": "ResidualNorm", "reduction_factor": 1e-10},
+        ],
+    }
+)
 
 logger = pGB.solver.config_solve_double(executor, A, b, x, solver_args)
 
@@ -96,9 +106,11 @@ logger = pGB.solver.config_solve_double(executor, A, b, x, solver_args)
 sol_local = pg.distributed.vector_local(x, dtype=value)
 
 if rank == 0:
-    print(f"[pyGinkgo distributed] N={N} ranks={size} "
-          f"converged={logger.has_converged()} "
-          f"iters={logger.get_num_iterations()}")
+    print(
+        f"[pyGinkgo distributed] N={N} ranks={size} "
+        f"converged={logger.has_converged()} "
+        f"iters={logger.get_num_iterations()}"
+    )
 
 # Gather the full solution on rank 0 just to print it (only for this demo).
 full = comm.gather(np.asarray(sol_local).ravel(), root=0)

--- a/examples/distributed_solver.py
+++ b/examples/distributed_solver.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Imad Kissami
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -19,4 +19,5 @@ set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/gmres.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/solver/triangular.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/factorization/factorization.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp_bindings/distributed.cpp
     PARENT_SCOPE)

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/python.cpp

--- a/src/cpp_bindings/CMakeLists.txt
+++ b/src/cpp_bindings/CMakeLists.txt
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 #
 # SPDX-FileCopyrightText: 2024 pyGinkgo authors
-# SPDX-FileCopyrightText: 2026 Imad Kissami
 
 set(PYGINKGO_CPP_SOURCES
     ${PROJECT_SOURCE_DIR}/src/cpp_bindings/python.cpp

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -1,0 +1,414 @@
+// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+//
+// SPDX-License-Identifier: MIT
+
+#include "python.hpp"
+#include "utils.hpp"
+
+#include <algorithm>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+namespace py = pybind11;
+
+#if GINKGO_BUILD_MPI
+
+#include <mpi.h>
+
+#include <ginkgo/core/base/device_matrix_data.hpp>
+#include <ginkgo/core/base/mpi.hpp>
+#include <ginkgo/core/distributed/matrix.hpp>
+#include <ginkgo/core/distributed/partition.hpp>
+#include <ginkgo/core/distributed/vector.hpp>
+#include <ginkgo/core/matrix/dense.hpp>
+
+namespace dist = gko::experimental::distributed;
+namespace mpi = gko::experimental::mpi;
+
+using LIT = gko::int32;  // local index type
+using GIT = gko::int32;  // global index type (int32: matches manapy ls_compute
+                         // triplets; caps global DOFs at ~2.1e9, fine here)
+using PartT = dist::Partition<LIT, GIT>;
+
+static mpi::communicator comm_from_fortran(long fortran_handle)
+{
+    MPI_Comm c = MPI_Comm_f2c(static_cast<MPI_Fint>(fortran_handle));
+    return mpi::communicator(c);
+}
+
+static py::buffer_info checked_1d(py::array array, const char* name)
+{
+    auto info = array.request();
+    if (info.ndim != 1) {
+        std::ostringstream os;
+        os << name << " must be a 1-D array, got " << info.ndim << " dimensions";
+        throw py::value_error(os.str());
+    }
+    return info;
+}
+
+static void check_same_length(py::ssize_t lhs, const char* lhs_name,
+                              py::ssize_t rhs, const char* rhs_name)
+{
+    if (lhs != rhs) {
+        std::ostringstream os;
+        os << lhs_name << " and " << rhs_name << " must have matching lengths ("
+           << lhs << " != " << rhs << ")";
+        throw py::value_error(os.str());
+    }
+}
+
+template <typename T>
+static gko::array<T> host_array_from_numpy(
+    std::shared_ptr<const gko::Executor> host, py::array_t<T> array,
+    const char* name)
+{
+    auto info = checked_1d(array, name);
+    auto n = static_cast<gko::size_type>(info.shape[0]);
+    gko::array<T> out(host, n);
+    std::copy_n(static_cast<const T*>(info.ptr), n, out.get_data());
+    return out;
+}
+
+template <typename IndexType>
+static void validate_global_indices(py::array_t<IndexType> array, const char* name,
+                                    gko::size_type global_size)
+{
+    auto info = checked_1d(array, name);
+    const auto* data = static_cast<const IndexType*>(info.ptr);
+    for (py::ssize_t i = 0; i < info.shape[0]; ++i) {
+        const auto idx = data[i];
+        if (idx < 0 || static_cast<gko::size_type>(idx) >= global_size) {
+            std::ostringstream os;
+            os << name << " contains out-of-range global index " << idx
+               << " at position " << i << " for global size " << global_size;
+            throw py::value_error(os.str());
+        }
+    }
+}
+
+static void validate_partition_size(const PartT& partition,
+                                    gko::size_type global_size)
+{
+    if (static_cast<gko::size_type>(partition.get_size()) != global_size) {
+        std::ostringstream os;
+        os << "partition size (" << partition.get_size()
+           << ") must match global_size (" << global_size << ")";
+        throw py::value_error(os.str());
+    }
+}
+
+#ifdef GINKGO_BUILD_CUDA
+// Extract a device pointer + element count from a 1-D __cuda_array_interface__
+// object (CuPy, numba device array, ...).
+template <typename T>
+static std::pair<T*, gko::size_type> cai_ptr_and_size(py::object obj)
+{
+    auto cai = obj.attr("__cuda_array_interface__").cast<py::dict>();
+    auto data = cai["data"].cast<py::tuple>();
+    auto shape = cai["shape"].cast<py::tuple>();
+    if (shape.size() != 1) {
+        throw py::value_error(
+            "__cuda_array_interface__ array must be 1-D for the distributed "
+            "binding");
+    }
+    return {reinterpret_cast<T*>(data[0].cast<uintptr_t>()),
+            shape[0].cast<gko::size_type>()};
+}
+#endif
+
+// 1-D length of a numpy host array OR a __cuda_array_interface__ device array.
+static gko::size_type pyobj_len(py::object obj, const char* name)
+{
+#ifdef GINKGO_BUILD_CUDA
+    if (py::hasattr(obj, "__cuda_array_interface__")) {
+        auto cai = obj.attr("__cuda_array_interface__").cast<py::dict>();
+        auto shape = cai["shape"].cast<py::tuple>();
+        if (shape.size() != 1) {
+            throw py::value_error(std::string(name) + " must be a 1-D array");
+        }
+        return shape[0].cast<gko::size_type>();
+    }
+#endif
+    auto info = py::array(obj).request();
+    if (info.ndim != 1) {
+        throw py::value_error(std::string(name) + " must be a 1-D array");
+    }
+    return static_cast<gko::size_type>(info.shape[0]);
+}
+
+// Build an owning gko::array<T> on `exec` from either a numpy host array
+// (copied) or a __cuda_array_interface__ device array (zero-copy view, then an
+// owning device->device copy so the array can be moved into device_matrix_data
+// independently of the Python source's lifetime).
+template <typename T>
+static gko::array<T> array_on_exec(std::shared_ptr<const gko::Executor> exec,
+                                   py::object obj, const char* name)
+{
+#ifdef GINKGO_BUILD_CUDA
+    if (py::hasattr(obj, "__cuda_array_interface__")) {
+        auto pn = cai_ptr_and_size<T>(obj);
+        auto view = gko::array<T>::view(exec, pn.second, pn.first);
+        return gko::array<T>{exec, view};
+    }
+#endif
+    py::array_t<T, py::array::c_style | py::array::forcecast> arr(obj);
+    auto info = checked_1d(arr, name);
+    auto n = static_cast<gko::size_type>(info.shape[0]);
+    auto host = exec->get_master();
+    gko::array<T> host_arr(host, n);
+    std::copy_n(static_cast<const T*>(info.ptr), n, host_arr.get_data());
+    return gko::array<T>{exec, host_arr};
+}
+
+static std::shared_ptr<PartT> build_partition(
+    std::shared_ptr<gko::Executor> exec,
+    py::array_t<int, py::array::c_style | py::array::forcecast> owners,
+    int num_parts)
+{
+    if (num_parts <= 0) {
+        throw py::value_error("num_parts must be positive");
+    }
+
+    auto owner_info = checked_1d(owners, "owners");
+    if (owner_info.shape[0] == 0) {
+        throw py::value_error("owners must not be empty");
+    }
+    const auto* owner_data = static_cast<const int*>(owner_info.ptr);
+    for (py::ssize_t i = 0; i < owner_info.shape[0]; ++i) {
+        if (owner_data[i] < 0 || owner_data[i] >= num_parts) {
+            std::ostringstream os;
+            os << "owners contains invalid part id " << owner_data[i]
+               << " at position " << i << " for num_parts=" << num_parts;
+            throw py::value_error(os.str());
+        }
+    }
+
+    auto host = gko::ReferenceExecutor::create();
+    auto mapping_host = host_array_from_numpy<int>(host, owners, "owners");
+    auto mapping = gko::array<int>(exec, mapping_host);
+    return gko::share(PartT::build_from_mapping(exec, mapping, num_parts));
+}
+
+template <typename ValueType>
+static std::shared_ptr<gko::LinOp> build_matrix(
+    std::shared_ptr<gko::Executor> exec, long comm_handle,
+    std::shared_ptr<PartT> partition, py::object rows, py::object cols,
+    py::object vals, gko::size_type global_size)
+{
+    auto n = pyobj_len(rows, "rows");
+    check_same_length(static_cast<py::ssize_t>(n), "rows",
+                      static_cast<py::ssize_t>(pyobj_len(cols, "cols")), "cols");
+    check_same_length(static_cast<py::ssize_t>(n), "rows",
+                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")), "vals");
+    validate_partition_size(*partition, global_size);
+
+    auto comm = comm_from_fortran(comm_handle);
+
+    // Assemble directly on the requested executor (device for CUDA). Inputs may
+    // be host numpy or device (__cuda_array_interface__) arrays; the latter are
+    // ingested zero-copy. The partition is already on `exec`, so assembly is
+    // executor-consistent (the host-staging workaround is no longer needed).
+    auto row_arr = array_on_exec<GIT>(exec, rows, "rows");
+    auto col_arr = array_on_exec<GIT>(exec, cols, "cols");
+    auto val_arr = array_on_exec<ValueType>(exec, vals, "vals");
+
+    gko::device_matrix_data<ValueType, GIT> data(
+        exec, gko::dim<2>{global_size, global_size}, std::move(row_arr),
+        std::move(col_arr), std::move(val_arr));
+
+    auto mat = dist::Matrix<ValueType, LIT, GIT>::create(exec, comm);
+    mat->read_distributed(data, partition, dist::assembly_mode::communicate);
+    return gko::share(std::move(mat));
+}
+
+template <typename ValueType>
+static std::shared_ptr<gko::LinOp> build_vector(
+    std::shared_ptr<gko::Executor> exec, long comm_handle,
+    std::shared_ptr<PartT> partition, py::object rows, py::object vals,
+    gko::size_type global_size)
+{
+    auto n = pyobj_len(rows, "rows");
+    check_same_length(static_cast<py::ssize_t>(n), "rows",
+                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")), "vals");
+    validate_partition_size(*partition, global_size);
+
+    auto comm = comm_from_fortran(comm_handle);
+
+    auto row_arr = array_on_exec<GIT>(exec, rows, "rows");
+    auto val_arr = array_on_exec<ValueType>(exec, vals, "vals");
+    auto nnz = row_arr.get_size();
+
+    gko::array<GIT> col_arr(exec, nnz);
+    col_arr.fill(GIT{0});
+
+    gko::device_matrix_data<ValueType, GIT> data(
+        exec, gko::dim<2>{global_size, 1}, std::move(row_arr),
+        std::move(col_arr), std::move(val_arr));
+
+    auto vec = dist::Vector<ValueType>::create(exec, comm);
+    vec->read_distributed(data, partition);
+    return gko::share(std::move(vec));
+}
+
+template <typename ValueType>
+static py::array_t<ValueType> vector_local(std::shared_ptr<gko::LinOp> v)
+{
+    auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
+    if (!vec) {
+        throw py::type_error(
+            "vector_local: object is not a distributed vector of the requested value type");
+    }
+    auto host = vec->get_executor()->get_master();
+    auto local = vec->get_local_vector();
+    auto host_local = gko::clone(host, local);
+    const auto nrows = static_cast<py::ssize_t>(host_local->get_size()[0]);
+    const auto ncols = static_cast<py::ssize_t>(host_local->get_size()[1]);
+    const auto stride = static_cast<py::ssize_t>(host_local->get_stride());
+    const auto* values = host_local->get_const_values();
+
+    if (ncols == 1) {
+        py::array_t<ValueType> out(nrows);
+        auto* out_data = static_cast<ValueType*>(out.request().ptr);
+        for (py::ssize_t row = 0; row < nrows; ++row) {
+            out_data[row] = values[row];
+        }
+        return out;
+    }
+
+    py::array_t<ValueType> out({nrows, ncols});
+    auto* out_data = static_cast<ValueType*>(out.request().ptr);
+    for (py::ssize_t col = 0; col < ncols; ++col) {
+        for (py::ssize_t row = 0; row < nrows; ++row) {
+            out_data[row * ncols + col] = values[row + col * stride];
+        }
+    }
+    return out;
+}
+
+// Overwrite a distributed vector's processor-local values IN PLACE (no
+// reallocation, no read_distributed). `vals` is a 1-D host numpy array or a
+// __cuda_array_interface__ device array whose length must equal the local size;
+// its entries are already in Ginkgo's processor-local ordering. Lets callers
+// reuse a single vector across solves instead of rebuilding it each time.
+template <typename ValueType>
+static void vector_set_local(std::shared_ptr<gko::LinOp> v, py::object vals)
+{
+    auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
+    if (!vec) {
+        throw py::type_error(
+            "vector_set_local: object is not a distributed vector of the "
+            "requested value type");
+    }
+    // The local part is owned by the vector; we only overwrite its values
+    // (no resize), so const_cast on the buffer is safe here.
+    auto* local = const_cast<gko::matrix::Dense<ValueType>*>(
+        vec->get_local_vector());
+    const auto nrows = local->get_size()[0];
+    const auto ncols = local->get_size()[1];
+    if (ncols != 1) {
+        throw py::value_error(
+            "vector_set_local supports column vectors only (ncols == 1)");
+    }
+    auto n = pyobj_len(vals, "vals");
+    if (n != nrows) {
+        std::ostringstream os;
+        os << "vals length (" << n << ") must match the vector's local size ("
+           << nrows << ")";
+        throw py::value_error(os.str());
+    }
+    auto exec = local->get_executor();
+    // Bring vals onto the vector's executor (host copy, or zero-copy device view
+    // then an owning copy), then overwrite the contiguous local buffer.
+    auto src = array_on_exec<ValueType>(exec, vals, "vals");
+    exec->copy(n, src.get_const_data(), local->get_values());
+}
+
+#ifdef GINKGO_BUILD_CUDA
+// Expose the device pointer + layout of a distributed vector's processor-local
+// part, so Python can wrap it zero-copy (CuPy / numba) without a device->host
+// copy. The buffer stays valid as long as the source vector is alive.
+template <typename ValueType>
+static py::tuple vector_local_device_info(std::shared_ptr<gko::LinOp> v)
+{
+    auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
+    if (!vec) {
+        throw py::type_error(
+            "vector_local_device: object is not a distributed vector of the "
+            "requested value type");
+    }
+    auto local = vec->get_local_vector();
+    return py::make_tuple(
+        reinterpret_cast<uintptr_t>(local->get_const_values()),
+        static_cast<py::ssize_t>(local->get_size()[0]),
+        static_cast<py::ssize_t>(local->get_size()[1]),
+        static_cast<py::ssize_t>(local->get_stride()));
+}
+#endif
+
+template <typename ValueType>
+static void init_distributed_for_type(py::module_& m, const std::string& vt)
+{
+    m.def(("matrix_" + vt).c_str(), &build_matrix<ValueType>, py::arg("exec"),
+          py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
+          py::arg("cols"), py::arg("vals"), py::arg("global_size"),
+          "Build a distributed Csr matrix from global COO triplets. The matrix "
+          "is square: its shape is global_size x global_size. Row/column indices "
+          "must lie in [0, global_size).");
+
+    m.def(("vector_" + vt).c_str(), &build_vector<ValueType>, py::arg("exec"),
+          py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
+          py::arg("vals"), py::arg("global_size"),
+          "Build a distributed vector from (global_row, value) entries. Global "
+          "rows not present in 'rows' default to zero.");
+
+    m.def(("vector_local_" + vt).c_str(), &vector_local<ValueType>,
+          py::arg("vector"),
+          "Return the processor-local part of a distributed vector as numpy.");
+
+    m.def(("vector_set_local_" + vt).c_str(), &vector_set_local<ValueType>,
+          py::arg("vector"), py::arg("vals"),
+          "Overwrite a distributed vector's processor-local values in place "
+          "(no reallocation). vals length must equal the local size.");
+
+#ifdef GINKGO_BUILD_CUDA
+    m.def(("vector_local_device_" + vt).c_str(),
+          &vector_local_device_info<ValueType>, py::arg("vector"),
+          "Return (device_ptr, nrows, ncols, stride) of a distributed vector's "
+          "processor-local part for zero-copy CuPy/numba wrapping.");
+#endif
+}
+
+void init_distributed(py::module_& m)
+{
+    py::class_<PartT, std::shared_ptr<PartT>>(m, "Partition")
+        .def("get_num_parts", &PartT::get_num_parts)
+        .def_property_readonly("size", [](const PartT& p) { return p.get_size(); })
+        .def("__repr__", [](const PartT& p) {
+            std::ostringstream os;
+            os << "<pyGinkgo.distributed.Partition size=" << p.get_size()
+               << " num_parts=" << p.get_num_parts() << ">";
+            return os.str();
+        });
+
+    m.def("build_partition", &build_partition, py::arg("exec"),
+          py::arg("owners"), py::arg("num_parts"),
+          "Build a distributed Partition from a global owner mapping "
+          "(owners[global_row] = rank).");
+
+    // half/bfloat16 distributed types are instantiated by Ginkgo only when it
+    // is built with GINKGO_ENABLE_HALF; PYGKO_ADAPT_HF compiles the half
+    // bindings out when half support is disabled (e.g. HALF=OFF on GCC 13).
+    PYGKO_ADAPT_HF(init_distributed_for_type<half>(m, "half"));
+    init_distributed_for_type<float>(m, "float");
+    init_distributed_for_type<double>(m, "double");
+
+    m.attr("available") = true;
+}
+
+#else  // GINKGO_BUILD_MPI
+
+void init_distributed(py::module_& m) { m.attr("available") = false; }
+
+#endif  // GINKGO_BUILD_MPI

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2026 Imad Kissami
+// SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -2,19 +2,17 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include "python.hpp"
-#include "utils.hpp"
-
 #include <algorithm>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 
+#include "python.hpp"
+#include "utils.hpp"
+
 namespace py = pybind11;
 
 #if GINKGO_BUILD_MPI
-
-#include <mpi.h>
 
 #include <ginkgo/core/base/device_matrix_data.hpp>
 #include <ginkgo/core/base/mpi.hpp>
@@ -22,6 +20,8 @@ namespace py = pybind11;
 #include <ginkgo/core/distributed/partition.hpp>
 #include <ginkgo/core/distributed/vector.hpp>
 #include <ginkgo/core/matrix/dense.hpp>
+
+#include <mpi.h>
 
 namespace dist = gko::experimental::distributed;
 namespace mpi = gko::experimental::mpi;
@@ -37,19 +37,20 @@ static mpi::communicator comm_from_fortran(long fortran_handle)
     return mpi::communicator(c);
 }
 
-static py::buffer_info checked_1d(py::array array, const char* name)
+static py::buffer_info checked_1d(py::array array, const char *name)
 {
     auto info = array.request();
     if (info.ndim != 1) {
         std::ostringstream os;
-        os << name << " must be a 1-D array, got " << info.ndim << " dimensions";
+        os << name << " must be a 1-D array, got " << info.ndim
+           << " dimensions";
         throw py::value_error(os.str());
     }
     return info;
 }
 
-static void check_same_length(py::ssize_t lhs, const char* lhs_name,
-                              py::ssize_t rhs, const char* rhs_name)
+static void check_same_length(py::ssize_t lhs, const char *lhs_name,
+                              py::ssize_t rhs, const char *rhs_name)
 {
     if (lhs != rhs) {
         std::ostringstream os;
@@ -62,21 +63,22 @@ static void check_same_length(py::ssize_t lhs, const char* lhs_name,
 template <typename T>
 static gko::array<T> host_array_from_numpy(
     std::shared_ptr<const gko::Executor> host, py::array_t<T> array,
-    const char* name)
+    const char *name)
 {
     auto info = checked_1d(array, name);
     auto n = static_cast<gko::size_type>(info.shape[0]);
     gko::array<T> out(host, n);
-    std::copy_n(static_cast<const T*>(info.ptr), n, out.get_data());
+    std::copy_n(static_cast<const T *>(info.ptr), n, out.get_data());
     return out;
 }
 
 template <typename IndexType>
-static void validate_global_indices(py::array_t<IndexType> array, const char* name,
+static void validate_global_indices(py::array_t<IndexType> array,
+                                    const char *name,
                                     gko::size_type global_size)
 {
     auto info = checked_1d(array, name);
-    const auto* data = static_cast<const IndexType*>(info.ptr);
+    const auto *data = static_cast<const IndexType *>(info.ptr);
     for (py::ssize_t i = 0; i < info.shape[0]; ++i) {
         const auto idx = data[i];
         if (idx < 0 || static_cast<gko::size_type>(idx) >= global_size) {
@@ -88,7 +90,7 @@ static void validate_global_indices(py::array_t<IndexType> array, const char* na
     }
 }
 
-static void validate_partition_size(const PartT& partition,
+static void validate_partition_size(const PartT &partition,
                                     gko::size_type global_size)
 {
     if (static_cast<gko::size_type>(partition.get_size()) != global_size) {
@@ -103,7 +105,7 @@ static void validate_partition_size(const PartT& partition,
 // Extract a device pointer + element count from a 1-D __cuda_array_interface__
 // object (CuPy, numba device array, ...).
 template <typename T>
-static std::pair<T*, gko::size_type> cai_ptr_and_size(py::object obj)
+static std::pair<T *, gko::size_type> cai_ptr_and_size(py::object obj)
 {
     auto cai = obj.attr("__cuda_array_interface__").cast<py::dict>();
     auto data = cai["data"].cast<py::tuple>();
@@ -113,13 +115,13 @@ static std::pair<T*, gko::size_type> cai_ptr_and_size(py::object obj)
             "__cuda_array_interface__ array must be 1-D for the distributed "
             "binding");
     }
-    return {reinterpret_cast<T*>(data[0].cast<uintptr_t>()),
+    return {reinterpret_cast<T *>(data[0].cast<uintptr_t>()),
             shape[0].cast<gko::size_type>()};
 }
 #endif
 
 // 1-D length of a numpy host array OR a __cuda_array_interface__ device array.
-static gko::size_type pyobj_len(py::object obj, const char* name)
+static gko::size_type pyobj_len(py::object obj, const char *name)
 {
 #ifdef GINKGO_BUILD_CUDA
     if (py::hasattr(obj, "__cuda_array_interface__")) {
@@ -144,7 +146,7 @@ static gko::size_type pyobj_len(py::object obj, const char* name)
 // independently of the Python source's lifetime).
 template <typename T>
 static gko::array<T> array_on_exec(std::shared_ptr<const gko::Executor> exec,
-                                   py::object obj, const char* name)
+                                   py::object obj, const char *name)
 {
 #ifdef GINKGO_BUILD_CUDA
     if (py::hasattr(obj, "__cuda_array_interface__")) {
@@ -158,7 +160,7 @@ static gko::array<T> array_on_exec(std::shared_ptr<const gko::Executor> exec,
     auto n = static_cast<gko::size_type>(info.shape[0]);
     auto host = exec->get_master();
     gko::array<T> host_arr(host, n);
-    std::copy_n(static_cast<const T*>(info.ptr), n, host_arr.get_data());
+    std::copy_n(static_cast<const T *>(info.ptr), n, host_arr.get_data());
     return gko::array<T>{exec, host_arr};
 }
 
@@ -175,7 +177,7 @@ static std::shared_ptr<PartT> build_partition(
     if (owner_info.shape[0] == 0) {
         throw py::value_error("owners must not be empty");
     }
-    const auto* owner_data = static_cast<const int*>(owner_info.ptr);
+    const auto *owner_data = static_cast<const int *>(owner_info.ptr);
     for (py::ssize_t i = 0; i < owner_info.shape[0]; ++i) {
         if (owner_data[i] < 0 || owner_data[i] >= num_parts) {
             std::ostringstream os;
@@ -199,9 +201,11 @@ static std::shared_ptr<gko::LinOp> build_matrix(
 {
     auto n = pyobj_len(rows, "rows");
     check_same_length(static_cast<py::ssize_t>(n), "rows",
-                      static_cast<py::ssize_t>(pyobj_len(cols, "cols")), "cols");
+                      static_cast<py::ssize_t>(pyobj_len(cols, "cols")),
+                      "cols");
     check_same_length(static_cast<py::ssize_t>(n), "rows",
-                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")), "vals");
+                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")),
+                      "vals");
     validate_partition_size(*partition, global_size);
 
     auto comm = comm_from_fortran(comm_handle);
@@ -231,7 +235,8 @@ static std::shared_ptr<gko::LinOp> build_vector(
 {
     auto n = pyobj_len(rows, "rows");
     check_same_length(static_cast<py::ssize_t>(n), "rows",
-                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")), "vals");
+                      static_cast<py::ssize_t>(pyobj_len(vals, "vals")),
+                      "vals");
     validate_partition_size(*partition, global_size);
 
     auto comm = comm_from_fortran(comm_handle);
@@ -258,7 +263,8 @@ static py::array_t<ValueType> vector_local(std::shared_ptr<gko::LinOp> v)
     auto vec = std::dynamic_pointer_cast<dist::Vector<ValueType>>(v);
     if (!vec) {
         throw py::type_error(
-            "vector_local: object is not a distributed vector of the requested value type");
+            "vector_local: object is not a distributed vector of the requested "
+            "value type");
     }
     auto host = vec->get_executor()->get_master();
     auto local = vec->get_local_vector();
@@ -266,11 +272,11 @@ static py::array_t<ValueType> vector_local(std::shared_ptr<gko::LinOp> v)
     const auto nrows = static_cast<py::ssize_t>(host_local->get_size()[0]);
     const auto ncols = static_cast<py::ssize_t>(host_local->get_size()[1]);
     const auto stride = static_cast<py::ssize_t>(host_local->get_stride());
-    const auto* values = host_local->get_const_values();
+    const auto *values = host_local->get_const_values();
 
     if (ncols == 1) {
         py::array_t<ValueType> out(nrows);
-        auto* out_data = static_cast<ValueType*>(out.request().ptr);
+        auto *out_data = static_cast<ValueType *>(out.request().ptr);
         for (py::ssize_t row = 0; row < nrows; ++row) {
             out_data[row] = values[row];
         }
@@ -278,7 +284,7 @@ static py::array_t<ValueType> vector_local(std::shared_ptr<gko::LinOp> v)
     }
 
     py::array_t<ValueType> out({nrows, ncols});
-    auto* out_data = static_cast<ValueType*>(out.request().ptr);
+    auto *out_data = static_cast<ValueType *>(out.request().ptr);
     for (py::ssize_t col = 0; col < ncols; ++col) {
         for (py::ssize_t row = 0; row < nrows; ++row) {
             out_data[row * ncols + col] = values[row + col * stride];
@@ -303,8 +309,8 @@ static void vector_set_local(std::shared_ptr<gko::LinOp> v, py::object vals)
     }
     // The local part is owned by the vector; we only overwrite its values
     // (no resize), so const_cast on the buffer is safe here.
-    auto* local = const_cast<gko::matrix::Dense<ValueType>*>(
-        vec->get_local_vector());
+    auto *local =
+        const_cast<gko::matrix::Dense<ValueType> *>(vec->get_local_vector());
     const auto nrows = local->get_size()[0];
     const auto ncols = local->get_size()[1];
     if (ncols != 1) {
@@ -319,8 +325,8 @@ static void vector_set_local(std::shared_ptr<gko::LinOp> v, py::object vals)
         throw py::value_error(os.str());
     }
     auto exec = local->get_executor();
-    // Bring vals onto the vector's executor (host copy, or zero-copy device view
-    // then an owning copy), then overwrite the contiguous local buffer.
+    // Bring vals onto the vector's executor (host copy, or zero-copy device
+    // view then an owning copy), then overwrite the contiguous local buffer.
     auto src = array_on_exec<ValueType>(exec, vals, "vals");
     exec->copy(n, src.get_const_data(), local->get_values());
 }
@@ -348,14 +354,15 @@ static py::tuple vector_local_device_info(std::shared_ptr<gko::LinOp> v)
 #endif
 
 template <typename ValueType>
-static void init_distributed_for_type(py::module_& m, const std::string& vt)
+static void init_distributed_for_type(py::module_ &m, const std::string &vt)
 {
-    m.def(("matrix_" + vt).c_str(), &build_matrix<ValueType>, py::arg("exec"),
-          py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
-          py::arg("cols"), py::arg("vals"), py::arg("global_size"),
-          "Build a distributed Csr matrix from global COO triplets. The matrix "
-          "is square: its shape is global_size x global_size. Row/column indices "
-          "must lie in [0, global_size).");
+    m.def(
+        ("matrix_" + vt).c_str(), &build_matrix<ValueType>, py::arg("exec"),
+        py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
+        py::arg("cols"), py::arg("vals"), py::arg("global_size"),
+        "Build a distributed Csr matrix from global COO triplets. The matrix "
+        "is square: its shape is global_size x global_size. Row/column indices "
+        "must lie in [0, global_size).");
 
     m.def(("vector_" + vt).c_str(), &build_vector<ValueType>, py::arg("exec"),
           py::arg("comm_handle"), py::arg("partition"), py::arg("rows"),
@@ -380,12 +387,13 @@ static void init_distributed_for_type(py::module_& m, const std::string& vt)
 #endif
 }
 
-void init_distributed(py::module_& m)
+void init_distributed(py::module_ &m)
 {
     py::class_<PartT, std::shared_ptr<PartT>>(m, "Partition")
         .def("get_num_parts", &PartT::get_num_parts)
-        .def_property_readonly("size", [](const PartT& p) { return p.get_size(); })
-        .def("__repr__", [](const PartT& p) {
+        .def_property_readonly("size",
+                               [](const PartT &p) { return p.get_size(); })
+        .def("__repr__", [](const PartT &p) {
             std::ostringstream os;
             os << "<pyGinkgo.distributed.Partition size=" << p.get_size()
                << " num_parts=" << p.get_num_parts() << ">";
@@ -409,6 +417,6 @@ void init_distributed(py::module_& m)
 
 #else  // GINKGO_BUILD_MPI
 
-void init_distributed(py::module_& m) { m.attr("available") = false; }
+void init_distributed(py::module_ &m) { m.attr("available") = false; }
 
 #endif  // GINKGO_BUILD_MPI

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -148,8 +148,8 @@ static gko::array<T> array_on_exec(std::shared_ptr<const gko::Executor> exec,
 {
 #ifdef GINKGO_BUILD_CUDA
     if (py::hasattr(obj, "__cuda_array_interface__")) {
-        auto pn = cai_ptr_and_size<T>(obj);
-        auto view = gko::array<T>::view(exec, pn.second, pn.first);
+        auto ptr_size = cai_ptr_and_size<T>(obj);
+        auto view = gko::array<T>::view(exec, ptr_size.second, ptr_size.first);
         return gko::array<T>{exec, view};
     }
 #endif

--- a/src/cpp_bindings/distributed.cpp
+++ b/src/cpp_bindings/distributed.cpp
@@ -72,14 +72,22 @@ static gko::array<T> host_array_from_numpy(
     return out;
 }
 
+// Enforce the advertised [0, global_size) contract on a global index array,
+// for both host and device inputs. The array has already been materialized on
+// its executor; device arrays are cloned to host for the scan because Ginkgo
+// exposes no public device-side bounds reduction (these are the COO index
+// triplets, so the extra host copy is a one-off at assembly time). Catching
+// bad indices here yields a Python ValueError instead of letting them reach
+// Ginkgo's assembly internals.
 template <typename IndexType>
-static void validate_global_indices(py::array_t<IndexType> array,
+static void validate_global_indices(const gko::array<IndexType> &indices,
                                     const char *name,
                                     gko::size_type global_size)
 {
-    auto info = checked_1d(array, name);
-    const auto *data = static_cast<const IndexType *>(info.ptr);
-    for (py::ssize_t i = 0; i < info.shape[0]; ++i) {
+    auto host = indices.get_executor()->get_master();
+    gko::array<IndexType> host_indices(host, indices);
+    const auto *data = host_indices.get_const_data();
+    for (gko::size_type i = 0; i < host_indices.get_size(); ++i) {
         const auto idx = data[i];
         if (idx < 0 || static_cast<gko::size_type>(idx) >= global_size) {
             std::ostringstream os;
@@ -114,6 +122,32 @@ static std::pair<T *, gko::size_type> cai_ptr_and_size(py::object obj)
         throw py::value_error(
             "__cuda_array_interface__ array must be 1-D for the distributed "
             "binding");
+    }
+    // The pointer is reinterpreted as T*, so the reported dtype must match
+    // exactly -- otherwise e.g. a float64 array handed to the float binding
+    // would be read as pairs of unrelated float32 values.
+    auto typestr = cai["typestr"].cast<std::string>();
+    auto expected = get_cuda_array_typestr<T>();
+    if (typestr != expected) {
+        throw py::value_error(
+            "__cuda_array_interface__ dtype mismatch: array reports '" +
+            typestr + "' but this binding expects '" + expected + "'");
+    }
+    // The view is treated as contiguous, so reject strided (e.g. sliced)
+    // arrays: `strides` must be absent, None, or a 1-element tuple ==
+    // sizeof(T).
+    if (cai.contains("strides")) {
+        py::handle strides_obj = cai["strides"];
+        if (!strides_obj.is_none()) {
+            auto strides = strides_obj.cast<py::tuple>();
+            if (strides.size() != 1 ||
+                strides[0].cast<py::ssize_t>() !=
+                    static_cast<py::ssize_t>(sizeof(T))) {
+                throw py::value_error(
+                    "__cuda_array_interface__ array must be contiguous in "
+                    "memory for the distributed binding");
+            }
+        }
     }
     return {reinterpret_cast<T *>(data[0].cast<uintptr_t>()),
             shape[0].cast<gko::size_type>()};
@@ -216,6 +250,8 @@ static std::shared_ptr<gko::LinOp> build_matrix(
     // executor-consistent (the host-staging workaround is no longer needed).
     auto row_arr = array_on_exec<GIT>(exec, rows, "rows");
     auto col_arr = array_on_exec<GIT>(exec, cols, "cols");
+    validate_global_indices<GIT>(row_arr, "rows", global_size);
+    validate_global_indices<GIT>(col_arr, "cols", global_size);
     auto val_arr = array_on_exec<ValueType>(exec, vals, "vals");
 
     gko::device_matrix_data<ValueType, GIT> data(
@@ -242,6 +278,7 @@ static std::shared_ptr<gko::LinOp> build_vector(
     auto comm = comm_from_fortran(comm_handle);
 
     auto row_arr = array_on_exec<GIT>(exec, rows, "rows");
+    validate_global_indices<GIT>(row_arr, "rows", global_size);
     auto val_arr = array_on_exec<ValueType>(exec, vals, "vals");
     auto nnz = row_arr.get_size();
 
@@ -344,6 +381,17 @@ static py::tuple vector_local_device_info(std::shared_ptr<gko::LinOp> v)
             "vector_local_device: object is not a distributed vector of the "
             "requested value type");
     }
+    auto exec = vec->get_executor();
+    // Only a CUDA executor's buffer is a valid device address; exposing a host
+    // pointer through __cuda_array_interface__ would have CuPy dereference host
+    // memory as a device address. Guard + synchronize, as array.cpp/dense.cpp
+    // do.
+    if (!std::dynamic_pointer_cast<const gko::CudaExecutor>(exec)) {
+        throw py::attribute_error(
+            "vector_local on_device=True is only available for distributed "
+            "vectors on CUDA executors");
+    }
+    exec->synchronize();
     auto local = vec->get_local_vector();
     return py::make_tuple(
         reinterpret_cast<uintptr_t>(local->get_const_values()),

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -21,6 +21,7 @@ void add_allocator_classes(py::module_ &);
 void add_stream_classes(py::module_ &);
 void add_dpcpp_queue_property_enum(py::module_ &);
 void add_executor_classes(py::module_ &);
+void init_distributed(py::module_ &);
 
 PYBIND11_MODULE(pyGinkgoBindings, m)
 {
@@ -88,4 +89,8 @@ PYBIND11_MODULE(pyGinkgoBindings, m)
     py::module_ module_preconditioner = m.def_submodule(
         "preconditioner", "Submodule for Ginkgos preconditioner type bindings");
     init_ilu_all_types(module_preconditioner);
+
+    py::module_ module_distributed = m.def_submodule(
+        "distributed", "Submodule for Ginkgos MPI-distributed type bindings");
+    init_distributed(module_distributed);
 }

--- a/src/cpp_bindings/python.cpp
+++ b/src/cpp_bindings/python.cpp
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
-// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -25,9 +25,12 @@ std::shared_ptr<gko::LinOp> config_solver(std::shared_ptr<gko::Executor> exec,
     // This example does not use existing data.
     auto reg = gko::config::registry();
     // generate the linopfactory on the given executors
+    // Global index type int32 (matches the int32-global distributed binding;
+    // unused for non-distributed types, which only need ValueType + int32 local).
     auto solver_gen =
-        gko::config::parse(config, reg,
-                           gko::config::make_type_descriptor<ValueType>())
+        gko::config::parse(
+            config, reg,
+            gko::config::make_type_descriptor<ValueType, gko::int32, gko::int32>())
             .on(exec);
 
     // Create solver

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
-// SPDX-FileCopyrightText: 2026 Imad Kissami
 //
 // SPDX-License-Identifier: MIT
 

--- a/src/cpp_bindings/solver/config_solver.cpp
+++ b/src/cpp_bindings/solver/config_solver.cpp
@@ -26,11 +26,13 @@ std::shared_ptr<gko::LinOp> config_solver(std::shared_ptr<gko::Executor> exec,
     auto reg = gko::config::registry();
     // generate the linopfactory on the given executors
     // Global index type int32 (matches the int32-global distributed binding;
-    // unused for non-distributed types, which only need ValueType + int32 local).
+    // unused for non-distributed types, which only need ValueType + int32
+    // local).
     auto solver_gen =
         gko::config::parse(
             config, reg,
-            gko::config::make_type_descriptor<ValueType, gko::int32, gko::int32>())
+            gko::config::make_type_descriptor<ValueType, gko::int32,
+                                              gko::int32>())
             .on(exec);
 
     // Create solver

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -12,3 +12,4 @@ from .rayleigh_ritz import *
 from . import gko_types
 from . import solver
 from . import preconditioner
+from . import distributed

--- a/src/pyGinkgo/__init__.py
+++ b/src/pyGinkgo/__init__.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
-# SPDX-FileCopyrightText: 2026 Imad Kissami
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/pyGinkgo/distributed.py
+++ b/src/pyGinkgo/distributed.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+#
+# SPDX-License-Identifier: MIT
+
+from .pyGinkgoBindings import distributed as _distributed
+
+available = bool(_distributed.available)
+Partition = getattr(_distributed, "Partition", None)
+
+# Value types the API understands. Which ones are actually compiled depends on
+# the Ginkgo build (half requires GINKGO_ENABLE_HALF); _binding() checks at call
+# time and raises if a requested dtype is unavailable in this build.
+_VALID_DTYPES = ("half", "float", "double")
+
+
+def _require_available():
+    if not available:
+        raise RuntimeError(
+            "pyGinkgo distributed bindings are unavailable; build Ginkgo with MPI support."
+        )
+
+
+def _binding(prefix, dtype):
+    """Resolve a typed binding (e.g. ``matrix_double``), validating availability."""
+    _require_available()
+    if dtype not in _VALID_DTYPES:
+        raise ValueError(f"dtype must be one of {_VALID_DTYPES}, got {dtype!r}")
+    fn = getattr(_distributed, f"{prefix}_{dtype}", None)
+    if fn is None:
+        raise ValueError(
+            f"dtype {dtype!r} is not available in this build "
+            f"(Ginkgo built without {dtype} support)."
+        )
+    return fn
+
+
+def _comm_handle(comm):
+    """Accept an mpi4py communicator or an already-converted Fortran MPI handle."""
+    if isinstance(comm, int):
+        return comm
+    py2f = getattr(comm, "py2f", None)
+    if py2f is None:
+        raise TypeError(
+            "comm must be an mpi4py communicator or an integer MPI_Comm handle "
+            "(as returned by comm.py2f())."
+        )
+    return py2f()
+
+
+def build_partition(exec, owners, num_parts):
+    _require_available()
+    return _distributed.build_partition(exec, owners, num_parts)
+
+
+def matrix(exec, comm, partition, rows, cols, vals, global_size, dtype="double"):
+    return _binding("matrix", dtype)(
+        exec, _comm_handle(comm), partition, rows, cols, vals, global_size
+    )
+
+
+def vector(exec, comm, partition, rows, vals, global_size, dtype="double"):
+    return _binding("vector", dtype)(
+        exec, _comm_handle(comm), partition, rows, vals, global_size
+    )
+
+
+_TYPESTR = {"double": "<f8", "float": "<f4", "half": "<f2"}
+_ITEMSIZE = {"double": 8, "float": 4, "half": 2}
+
+
+class _DeviceArray:
+    """Zero-copy ``__cuda_array_interface__`` view over a distributed vector's
+    local device buffer. Holds a reference to the source vector so the GPU
+    memory stays alive. Wrap with ``cupy.asarray(obj)`` or
+    ``numba.cuda.as_cuda_array(obj)``."""
+
+    def __init__(self, vector, ptr, shape, strides, typestr):
+        self._vector = vector  # keep-alive: GPU buffer is owned by the vector
+        self.__cuda_array_interface__ = {
+            "shape": shape,
+            "typestr": typestr,
+            "data": (ptr, False),  # (device pointer, read-only=False)
+            "strides": strides,
+            "version": 3,
+        }
+
+
+def vector_set_local(vector, vals, dtype="double"):
+    """Overwrite a distributed vector's processor-local values in place (no
+    reallocation, no re-distribution). ``vals`` may be a host numpy array or a
+    ``__cuda_array_interface__`` device array; its length must equal the
+    vector's local size and its entries must already be in Ginkgo's
+    processor-local ordering. Use to reuse a vector across solves instead of
+    rebuilding it with :func:`vector` every time."""
+    return _binding("vector_set_local", dtype)(vector, vals)
+
+
+def vector_local(vector, dtype="double", on_device=False):
+    """Processor-local part of a distributed vector.
+
+    on_device=False -> host numpy array (device->host copy).
+    on_device=True  -> a __cuda_array_interface__ wrapper over the device buffer
+                       (zero-copy); requires a CUDA-enabled build.
+    """
+    if not on_device:
+        return _binding("vector_local", dtype)(vector)
+    ptr, nrows, ncols, stride = _binding("vector_local_device", dtype)(vector)
+    itemsize = _ITEMSIZE[dtype]
+    if ncols == 1:
+        shape, strides = (nrows,), None  # contiguous
+    else:
+        # Ginkgo Dense is row-major with leading dimension `stride`.
+        shape, strides = (nrows, ncols), (stride * itemsize, itemsize)
+    return _DeviceArray(vector, ptr, shape, strides, _TYPESTR[dtype])
+
+
+if available:
+    # Re-export the typed bindings that this build actually compiled.
+    for _prefix in ("matrix", "vector", "vector_local", "vector_set_local"):
+        for _dtype in _VALID_DTYPES:
+            _name = f"{_prefix}_{_dtype}"
+            _fn = getattr(_distributed, _name, None)
+            if _fn is not None:
+                globals()[_name] = _fn
+    del _prefix, _dtype, _name, _fn
+
+
+__all__ = [
+    "available",
+    "Partition",
+    "build_partition",
+    "matrix",
+    "vector",
+    "vector_local",
+    "vector_set_local",
+]

--- a/src/pyGinkgo/distributed.py
+++ b/src/pyGinkgo/distributed.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+# SPDX-FileCopyrightText: 2026 Imad Kissami
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/pyGinkgo/distributed.py
+++ b/src/pyGinkgo/distributed.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2026 Imad Kissami
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
 #
 # SPDX-License-Identifier: MIT
 

--- a/tests/pyGinkgo/CMakeLists.txt
+++ b/tests/pyGinkgo/CMakeLists.txt
@@ -20,3 +20,26 @@ endfunction()
 pyginkgo_python_test(solve)
 pyginkgo_python_test(RR)
 pyginkgo_python_test(core)
+
+# Distributed / MPI bindings. The test file skips itself gracefully when the
+# build has no MPI support or when mpi4py is missing, so it is always registered
+# (the wrapper-layer tests run even in a CPU-only, MPI-off build).
+# PYGINKGO_GINKGO_HAS_MPI is set by the top-level CMakeLists before this
+# directory is added.
+pyginkgo_python_test(distributed)
+
+# In an MPI-enabled build additionally run the distributed suite under an MPI
+# launcher with multiple ranks, so the off-process communication paths are
+# actually exercised (a single-rank pytest run keeps everything process-local).
+if(PYGINKGO_GINKGO_HAS_MPI AND MPIEXEC_EXECUTABLE)
+  # Two ranks keeps the run cheap and avoids OpenMPI slot oversubscription on
+  # the small (2-core) CI runners while still crossing at least one rank
+  # boundary.
+  add_test(
+    NAME pyginkgo_distributed_mpi_test
+    COMMAND
+      ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
+      ${Python_EXECUTABLE} -m pytest -vv -rs -p no:cacheprovider
+      ${CMAKE_CURRENT_SOURCE_DIR}/test_distributed.py ${MPIEXEC_POSTFLAGS}
+    WORKING_DIRECTORY ${PYGINKGO_TESTS_WORK_DIR})
+endif()

--- a/tests/pyGinkgo/CMakeLists.txt
+++ b/tests/pyGinkgo/CMakeLists.txt
@@ -37,9 +37,12 @@ if(PYGINKGO_GINKGO_HAS_MPI AND MPIEXEC_EXECUTABLE)
   # boundary.
   add_test(
     NAME pyginkgo_distributed_mpi_test
+    # FindMPI layout: mpiexec <NUMPROC_FLAG> <N> <PREFLAGS> <target> <POSTFLAGS>
+    # <args>. POSTFLAGS must sit right after the target (python), not after the
+    # pytest args, or non-empty postflags would be handed to pytest.
     COMMAND
       ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ${MPIEXEC_PREFLAGS}
-      ${Python_EXECUTABLE} -m pytest -vv -rs -p no:cacheprovider
-      ${CMAKE_CURRENT_SOURCE_DIR}/test_distributed.py ${MPIEXEC_POSTFLAGS}
+      ${Python_EXECUTABLE} ${MPIEXEC_POSTFLAGS} -m pytest -vv -rs -p
+      no:cacheprovider ${CMAKE_CURRENT_SOURCE_DIR}/test_distributed.py
     WORKING_DIRECTORY ${PYGINKGO_TESTS_WORK_DIR})
 endif()

--- a/tests/pyGinkgo/test_distributed.py
+++ b/tests/pyGinkgo/test_distributed.py
@@ -1,0 +1,481 @@
+# SPDX-FileCopyrightText: 2024 - 2026 pyGinkgo authors
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit tests for the MPI-distributed pyGinkgo bindings (``pyGinkgo.distributed``).
+
+The functional tests build the 1-D Poisson system ``A x = b`` (tri-diagonal
+Laplacian, ``b = 1``) exactly like ``examples/distributed_solver.py`` and drive
+it through a distributed CG solve.  They are written to be correct at *any* rank
+count:
+
+* run plainly (``pytest test_distributed.py``) they execute on a single rank and
+  still exercise the full assemble/solve/read-back path;
+* run under an MPI launcher (``mpirun -n 4 python -m pytest test_distributed.py``)
+  they additionally exercise the off-process communication paths.
+
+Every test is parametrised over the executors available in this build/host --
+CPU (Reference) always, CUDA and ROCm/HIP when a device is present -- so the same
+assertions cover the CPU and GPU code paths.  Anything that cannot run in the
+current environment (build without MPI, no GPU, no ``mpi4py``/``cupy``) is
+skipped rather than failed, so ``-rs`` reports exactly what was and was not
+covered.
+"""
+
+import json
+
+import numpy as np
+import pytest
+
+import pyGinkgo.pyGinkgoBindings as pGB
+from pyGinkgo import distributed as dist
+
+
+# --------------------------------------------------------------------------- #
+#  Capability probes
+# --------------------------------------------------------------------------- #
+DIST_AVAILABLE = bool(dist.available)
+
+requires_dist = pytest.mark.skipif(
+    not DIST_AVAILABLE,
+    reason="pyGinkgo built without MPI support (GINKGO_BUILD_MPI=ON required)",
+)
+
+# numpy dtype for each value-type name understood by the distributed bindings.
+_NP_DTYPE = {"half": np.float16, "float": np.float32, "double": np.float64}
+
+
+def _cuda_available():
+    try:
+        return hasattr(pGB, "CudaExecutor") and pGB.CudaExecutor.get_num_devices() > 0
+    except RuntimeError:
+        return False
+
+
+def _hip_available():
+    try:
+        return hasattr(pGB, "HipExecutor") and pGB.HipExecutor.get_num_devices() > 0
+    except RuntimeError:
+        return False
+
+
+def _dist_dtypes():
+    """Value types the distributed bindings actually compiled in this build.
+
+    float/double are always instantiated when MPI is enabled; half only when
+    Ginkgo was built with GINKGO_ENABLE_HALF (re-exported as ``vector_half``).
+    """
+    dtypes = ["float", "double"]
+    if DIST_AVAILABLE and hasattr(dist, "vector_half"):
+        dtypes.append("half")
+    return dtypes
+
+
+def _has_device_binding(dtype):
+    """True if the zero-copy ``vector_local_device_<dtype>`` (CUDA-only) exists."""
+    return getattr(dist._distributed, f"vector_local_device_{dtype}", None) is not None
+
+
+# --------------------------------------------------------------------------- #
+#  Fixtures
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def comm():
+    """The MPI communicator.  Skips the whole module if mpi4py is missing."""
+    MPI = pytest.importorskip("mpi4py.MPI")
+    return MPI.COMM_WORLD
+
+
+@pytest.fixture(params=["cpu", "cuda", "hip"])
+def executor(request):
+    """A fresh executor for each supported backend; GPU backends skip when absent.
+
+    CUDA and ROCm/HIP remain in the parameter list even when no device is present
+    so ``-rs`` reports them as skipped (matching test_cuda_executor.py's style).
+    """
+    backend = request.param
+    if backend == "cpu":
+        return pGB.ReferenceExecutor()
+    if backend == "cuda":
+        if not _cuda_available():
+            pytest.skip("CUDA is not available")
+        return pGB.CudaExecutor(0, pGB.ReferenceExecutor())
+    if backend == "hip":
+        if not _hip_available():
+            pytest.skip("HIP is not available")
+        return pGB.HipExecutor(0, pGB.ReferenceExecutor())
+    raise AssertionError(f"unknown backend {backend!r}")
+
+
+# --------------------------------------------------------------------------- #
+#  Helpers -- 1-D Laplacian, contiguous block row distribution (PETSc-style)
+# --------------------------------------------------------------------------- #
+def _block_distribution(N, comm):
+    """owners[g] = rank, plus this rank's [start, end) contiguous block."""
+    rank, size = comm.Get_rank(), comm.Get_size()
+    counts = [N // size + (1 if r < N % size else 0) for r in range(size)]
+    offsets = np.concatenate(([0], np.cumsum(counts))).astype(np.int32)
+    start, end = int(offsets[rank]), int(offsets[rank + 1])
+    owners = np.empty(N, dtype=np.int32)
+    for r in range(size):
+        owners[offsets[r] : offsets[r + 1]] = r
+    return owners, start, end
+
+
+def _laplacian_triplets(start, end, N, np_dtype):
+    """Global COO triplets for the owned rows of the [-1, 2, -1] Laplacian."""
+    rows, cols, vals = [], [], []
+    for i in range(start, end):
+        rows.append(i)
+        cols.append(i)
+        vals.append(2.0)
+        if i > 0:
+            rows.append(i)
+            cols.append(i - 1)
+            vals.append(-1.0)
+        if i < N - 1:
+            rows.append(i)
+            cols.append(i + 1)
+            vals.append(-1.0)
+    return (
+        np.asarray(rows, dtype=np.int32),
+        np.asarray(cols, dtype=np.int32),
+        np.asarray(vals, dtype=np_dtype),
+    )
+
+
+def _dense_laplacian(N):
+    A = 2.0 * np.eye(N) - np.eye(N, k=1) - np.eye(N, k=-1)
+    return A
+
+
+def _gather_global(local, comm):
+    """Concatenate the per-rank local slices in rank order into the full vector.
+
+    The block partition assigns rank r the contiguous global rows it owns and
+    keeps them in ascending order within the local part, so rank-order
+    concatenation reproduces the global ordering (see examples/distributed_solver.py).
+    """
+    pieces = comm.allgather(np.asarray(local).ravel())
+    return np.concatenate(pieces)
+
+
+# --------------------------------------------------------------------------- #
+#  Pure-Python wrapper layer -- runs even in a build WITHOUT MPI
+# --------------------------------------------------------------------------- #
+class TestWrapperLayer:
+    def test_available_is_bool(self):
+        assert isinstance(dist.available, bool)
+
+    def test_public_exports(self):
+        for name in (
+            "available",
+            "build_partition",
+            "matrix",
+            "vector",
+            "vector_local",
+            "vector_set_local",
+        ):
+            assert name in dist.__all__
+
+    def test_comm_handle_passes_through_int(self):
+        assert dist._comm_handle(42) == 42
+
+    def test_comm_handle_uses_py2f(self):
+        class FakeComm:
+            def py2f(self):
+                return 7
+
+        assert dist._comm_handle(FakeComm()) == 7
+
+    def test_comm_handle_rejects_bad_object(self):
+        with pytest.raises(TypeError, match="mpi4py communicator"):
+            dist._comm_handle(object())
+
+    def test_require_available_matches_flag(self):
+        if DIST_AVAILABLE:
+            assert dist._require_available() is None
+        else:
+            with pytest.raises(
+                RuntimeError, match="distributed bindings are unavailable"
+            ):
+                dist._require_available()
+
+    @requires_dist
+    def test_binding_rejects_unknown_dtype(self):
+        with pytest.raises(ValueError, match="dtype must be one of"):
+            dist._binding("vector", "float128")
+
+    @pytest.mark.skipif(DIST_AVAILABLE, reason="only meaningful without MPI support")
+    def test_matrix_raises_when_unavailable(self):
+        with pytest.raises(RuntimeError, match="distributed bindings are unavailable"):
+            dist.matrix(None, 0, None, None, None, None, 1)
+
+
+# --------------------------------------------------------------------------- #
+#  Partition
+# --------------------------------------------------------------------------- #
+@requires_dist
+class TestPartition:
+    def test_build_and_properties(self, executor, comm):
+        N, size = 12, comm.Get_size()
+        owners, _, _ = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+        assert part.size == N
+        assert part.get_num_parts() == size
+        assert "Partition" in repr(part)
+
+    def test_rejects_non_positive_num_parts(self, executor):
+        owners = np.zeros(4, dtype=np.int32)
+        with pytest.raises(ValueError, match="num_parts must be positive"):
+            dist.build_partition(executor, owners, 0)
+
+    def test_rejects_empty_owners(self, executor):
+        with pytest.raises(ValueError, match="owners must not be empty"):
+            dist.build_partition(executor, np.empty(0, dtype=np.int32), 1)
+
+    def test_rejects_out_of_range_part_id(self, executor):
+        owners = np.array([0, 1, 5, 0], dtype=np.int32)  # 5 >= num_parts
+        with pytest.raises(ValueError, match="invalid part id"):
+            dist.build_partition(executor, owners, 2)
+
+
+# --------------------------------------------------------------------------- #
+#  Distributed matrix / vector assembly and read-back
+# --------------------------------------------------------------------------- #
+@requires_dist
+class TestAssembly:
+    @pytest.mark.parametrize("dtype", _dist_dtypes())
+    def test_vector_local_roundtrips_global_values(self, executor, comm, dtype):
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+
+        owned = np.arange(start, end, dtype=np.int32)
+        # Distinct value per global row so the ordering is checked, not just sums.
+        owned_vals = (owned + 1).astype(_NP_DTYPE[dtype])
+        vec = dist.vector(executor, comm, part, owned, owned_vals, N, dtype=dtype)
+
+        local = dist.vector_local(vec, dtype=dtype)
+        assert local.shape[0] == owned.size
+        np.testing.assert_allclose(np.asarray(local).ravel(), owned_vals)
+
+        full = _gather_global(local, comm)
+        np.testing.assert_allclose(full, np.arange(1, N + 1))
+
+    @pytest.mark.parametrize("dtype", _dist_dtypes())
+    def test_vector_set_local_overwrites_in_place(self, executor, comm, dtype):
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+
+        owned = np.arange(start, end, dtype=np.int32)
+        vec = dist.vector(
+            executor,
+            comm,
+            part,
+            owned,
+            np.zeros(owned.size, dtype=_NP_DTYPE[dtype]),
+            N,
+            dtype=dtype,
+        )
+
+        replacement = (100 + np.arange(owned.size)).astype(_NP_DTYPE[dtype])
+        dist.vector_set_local(vec, replacement, dtype=dtype)
+
+        np.testing.assert_allclose(
+            np.asarray(dist.vector_local(vec, dtype=dtype)).ravel(), replacement
+        )
+
+    def test_matrix_builds(self, executor, comm):
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+        rows, cols, vals = _laplacian_triplets(start, end, N, np.float64)
+        A = dist.matrix(executor, comm, part, rows, cols, vals, N, dtype="double")
+        assert A is not None
+
+
+# --------------------------------------------------------------------------- #
+#  End-to-end distributed CG solve  (CPU + GPU)
+# --------------------------------------------------------------------------- #
+@requires_dist
+class TestDistributedSolve:
+    # half is too inaccurate for a meaningful residual check on this system.
+    # reduction_factor / comparison tolerance per precision: 1e-10 is below the
+    # float32 residual floor, so CG would never satisfy it and never converge.
+    @pytest.mark.parametrize(
+        "dtype, reduction, tol",
+        [
+            pytest.param("double", 1e-10, 1e-6, id="double"),
+            pytest.param("float", 1e-5, 1e-2, id="float"),
+        ],
+    )
+    def test_cg_solves_poisson(self, executor, comm, dtype, reduction, tol):
+        if dtype not in _dist_dtypes():
+            pytest.skip(f"build has no distributed {dtype} bindings")
+
+        N, size = 24, comm.Get_size()
+        np_dtype = _NP_DTYPE[dtype]
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+
+        rows, cols, vals = _laplacian_triplets(start, end, N, np_dtype)
+        A = dist.matrix(executor, comm, part, rows, cols, vals, N, dtype=dtype)
+
+        owned = np.arange(start, end, dtype=np.int32)
+        b = dist.vector(
+            executor,
+            comm,
+            part,
+            owned,
+            np.ones(owned.size, dtype=np_dtype),
+            N,
+            dtype=dtype,
+        )
+        x = dist.vector(
+            executor,
+            comm,
+            part,
+            owned,
+            np.zeros(owned.size, dtype=np_dtype),
+            N,
+            dtype=dtype,
+        )
+
+        solver_args = json.dumps(
+            {
+                "type": "solver::Cg",
+                "criteria": [
+                    {"type": "Iteration", "max_iters": 1000},
+                    {"type": "ResidualNorm", "reduction_factor": reduction},
+                ],
+            }
+        )
+        config_solve = getattr(pGB.solver, f"config_solve_{dtype}")
+        logger = config_solve(executor, A, b, x, solver_args)
+
+        assert logger.has_converged()
+        assert 0 < logger.get_num_iterations() <= 1000
+
+        # Compare the reassembled global solution against a dense reference.
+        x_full = _gather_global(dist.vector_local(x, dtype=dtype), comm)
+        x_ref = np.linalg.solve(_dense_laplacian(N), np.ones(N))
+        np.testing.assert_allclose(x_full, x_ref, rtol=tol, atol=tol)
+
+
+# --------------------------------------------------------------------------- #
+#  Error paths in the C++ binding layer
+# --------------------------------------------------------------------------- #
+@requires_dist
+class TestBindingErrors:
+    def test_comm_handle_type_error(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        owned = np.arange(start, end, dtype=np.int32)
+        with pytest.raises(TypeError, match="mpi4py communicator"):
+            dist.vector(
+                executor, object(), part, owned, np.ones(owned.size), N, dtype="double"
+            )
+
+    def test_matrix_rejects_mismatched_lengths(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        rows = np.array([start], dtype=np.int32)
+        cols = np.array([start, start], dtype=np.int32)  # one too many
+        vals = np.array([2.0], dtype=np.float64)
+        with pytest.raises(ValueError, match="matching lengths"):
+            dist.matrix(executor, comm, part, rows, cols, vals, N, dtype="double")
+
+    def test_matrix_rejects_partition_size_mismatch(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        rows, cols, vals = _laplacian_triplets(start, end, N, np.float64)
+        with pytest.raises(ValueError, match="partition size"):
+            dist.matrix(executor, comm, part, rows, cols, vals, N + 1, dtype="double")
+
+    def test_vector_set_local_rejects_wrong_length(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        owned = np.arange(start, end, dtype=np.int32)
+        vec = dist.vector(
+            executor, comm, part, owned, np.zeros(owned.size), N, dtype="double"
+        )
+        with pytest.raises(ValueError, match="must match the vector's local size"):
+            dist.vector_set_local(vec, np.ones(owned.size + 1), dtype="double")
+
+    def test_vector_local_rejects_wrong_value_type(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        owned = np.arange(start, end, dtype=np.int32)
+        vec = dist.vector(
+            executor, comm, part, owned, np.zeros(owned.size), N, dtype="double"
+        )
+        with pytest.raises(TypeError, match="not a distributed vector"):
+            dist.vector_local(vec, dtype="float")
+
+
+# --------------------------------------------------------------------------- #
+#  GPU zero-copy device buffer path (CUDA only -- __cuda_array_interface__)
+# --------------------------------------------------------------------------- #
+@requires_dist
+class TestDeviceBuffer:
+    @pytest.mark.parametrize("dtype", ["float", "double"])
+    def test_vector_local_on_device_matches_host(self, comm, dtype):
+        if not _cuda_available():
+            pytest.skip("CUDA is not available")
+        if not _has_device_binding(dtype):
+            pytest.skip("build has no CUDA zero-copy vector_local_device binding")
+        cp = pytest.importorskip("cupy")
+
+        executor = pGB.CudaExecutor(0, pGB.ReferenceExecutor())
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+        owned = np.arange(start, end, dtype=np.int32)
+        owned_vals = (owned + 1).astype(_NP_DTYPE[dtype])
+        vec = dist.vector(executor, comm, part, owned, owned_vals, N, dtype=dtype)
+
+        dev = dist.vector_local(vec, dtype=dtype, on_device=True)
+        assert hasattr(dev, "__cuda_array_interface__")
+        host_from_device = cp.asarray(dev).get()
+
+        host = np.asarray(dist.vector_local(vec, dtype=dtype)).ravel()
+        np.testing.assert_allclose(host_from_device.ravel(), host)
+        np.testing.assert_allclose(host_from_device.ravel(), owned_vals)
+
+    @pytest.mark.parametrize("dtype", ["float", "double"])
+    def test_vector_set_local_accepts_device_array(self, comm, dtype):
+        if not _cuda_available():
+            pytest.skip("CUDA is not available")
+        if not _has_device_binding(dtype):
+            pytest.skip("build has no CUDA zero-copy vector_local_device binding")
+        cp = pytest.importorskip("cupy")
+
+        executor = pGB.CudaExecutor(0, pGB.ReferenceExecutor())
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+        owned = np.arange(start, end, dtype=np.int32)
+        vec = dist.vector(
+            executor,
+            comm,
+            part,
+            owned,
+            np.zeros(owned.size, dtype=_NP_DTYPE[dtype]),
+            N,
+            dtype=dtype,
+        )
+
+        replacement = cp.asarray((100 + np.arange(owned.size)).astype(_NP_DTYPE[dtype]))
+        dist.vector_set_local(vec, replacement, dtype=dtype)
+
+        np.testing.assert_allclose(
+            np.asarray(dist.vector_local(vec, dtype=dtype)).ravel(),
+            (100 + np.arange(owned.size)).astype(_NP_DTYPE[dtype]),
+        )

--- a/tests/pyGinkgo/test_distributed.py
+++ b/tests/pyGinkgo/test_distributed.py
@@ -397,6 +397,27 @@ class TestBindingErrors:
         with pytest.raises(ValueError, match="partition size"):
             dist.matrix(executor, comm, part, rows, cols, vals, N + 1, dtype="double")
 
+    def test_matrix_rejects_out_of_range_index(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        # A single triplet whose column index lies outside [0, N), injected
+        # identically on every rank so the raise happens before read_distributed.
+        rows = np.array([start], dtype=np.int32)
+        cols = np.array([N], dtype=np.int32)  # out of range
+        vals = np.array([1.0], dtype=np.float64)
+        with pytest.raises(ValueError, match="out-of-range global index"):
+            dist.matrix(executor, comm, part, rows, cols, vals, N, dtype="double")
+
+    def test_vector_rejects_out_of_range_index(self, executor, comm):
+        N = 8
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, comm.Get_size())
+        rows = np.array([N], dtype=np.int32)  # out of range
+        vals = np.array([1.0], dtype=np.float64)
+        with pytest.raises(ValueError, match="out-of-range global index"):
+            dist.vector(executor, comm, part, rows, vals, N, dtype="double")
+
     def test_vector_set_local_rejects_wrong_length(self, executor, comm):
         N = 8
         owners, start, end = _block_distribution(N, comm)
@@ -479,3 +500,59 @@ class TestDeviceBuffer:
             np.asarray(dist.vector_local(vec, dtype=dtype)).ravel(),
             (100 + np.arange(owned.size)).astype(_NP_DTYPE[dtype]),
         )
+
+    @pytest.mark.parametrize("dtype", ["float", "double"])
+    def test_device_array_dtype_mismatch_is_rejected(self, comm, dtype):
+        # A device array whose dtype does not match the binding must be rejected
+        # rather than silently reinterpreted (cai_ptr_and_size validates typestr).
+        if not _cuda_available():
+            pytest.skip("CUDA is not available")
+        if not _has_device_binding(dtype):
+            pytest.skip("build has no CUDA zero-copy vector_local_device binding")
+        cp = pytest.importorskip("cupy")
+
+        executor = pGB.CudaExecutor(0, pGB.ReferenceExecutor())
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+        owned = np.arange(start, end, dtype=np.int32)
+        vec = dist.vector(
+            executor,
+            comm,
+            part,
+            owned,
+            np.zeros(owned.size, dtype=_NP_DTYPE[dtype]),
+            N,
+            dtype=dtype,
+        )
+
+        wrong_np = np.float64 if dtype == "float" else np.float32
+        bad = cp.asarray(np.zeros(owned.size, dtype=wrong_np))
+        with pytest.raises(ValueError, match="dtype mismatch"):
+            dist.vector_set_local(vec, bad, dtype=dtype)
+
+    @pytest.mark.parametrize("dtype", ["float", "double"])
+    def test_on_device_rejects_non_cuda_executor(self, comm, dtype):
+        # In a CUDA-enabled build, asking for the device buffer of a vector that
+        # lives on a CPU executor must raise rather than advertise a host pointer
+        # as CUDA memory. Needs only the CUDA binding compiled in, not a GPU.
+        if not _has_device_binding(dtype):
+            pytest.skip("build has no CUDA zero-copy vector_local_device binding")
+
+        executor = pGB.ReferenceExecutor()
+        N, size = 12, comm.Get_size()
+        owners, start, end = _block_distribution(N, comm)
+        part = dist.build_partition(executor, owners, size)
+        owned = np.arange(start, end, dtype=np.int32)
+        vec = dist.vector(
+            executor,
+            comm,
+            part,
+            owned,
+            np.zeros(owned.size, dtype=_NP_DTYPE[dtype]),
+            N,
+            dtype=dtype,
+        )
+
+        with pytest.raises(AttributeError, match="CUDA executors"):
+            dist.vector_local(vec, dtype=dtype, on_device=True)


### PR DESCRIPTION
Adds MPI-distributed matrix/vector support to pyGinkgo, including CUDA interoperability, solver integration, tests, and an example.

## Changes:

- Adds Python and C++ distributed APIs.
- Extends solver configuration and CMake for MPI.
- Adds distributed tests and a Poisson solver example.

This PR mostly extends https://github.com/Helmholtz-AI-Energy/pyGinkgo/pull/116 in order to run it in our CI.